### PR TITLE
Fix to make agent work with TLS 1.2

### DIFF
--- a/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/DefaultProfile.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/DefaultProfile.cs
@@ -156,6 +156,7 @@ namespace Mythic.C2Profiles
                 try
                 {
 #if USE_HTTPWEB
+                    ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072 | SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls;
                     HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create(Endpoint);
                     request.KeepAlive = false;
                     request.Method = "Post";


### PR DESCRIPTION
The agent does not seem to work when using redirectors/HTTPS with TLS 1.2. The agent hangs in line 167:

`Stream reqStream = request.GetRequestStream();`

The piece of code fix the issue:

`ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072 | SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls;`
