### PR TITLE
Fix command_line argument in Keylog

### DIFF
--- a/Payload_Type/Apollo/mythic/agent_functions/keylog.py
+++ b/Payload_Type/Apollo/mythic/agent_functions/keylog.py
@@ -19,7 +19,7 @@ class KeylogArguments(TaskArguments):
         if len(self.command_line) == 0:
             raise Exception("Invalid number of parameters passed.\n\tUsage: {}".format(KeylogCommand.help_cmd))
         if self.command_line[0] == "{":
-            self.load_args_from_json_string()
+            self.load_args_from_json_string(self.command_line)
         else:
             valid_arch = ["x86", "x64"]
             parts = self.command_line.split()


### PR DESCRIPTION
Attempting to use `keylog` would fail at the Mythic level with:

```
keylog {"PID":22196,"Process Architecture":"x64"}
[-] Mythic error while creating/running create_tasking: 
load_args_from_json_string() missing 1 required positional argument: 'command_line'
```

Modified `agent_functions/keylog.py` to load the command_line args like every other agent function. Really minor fix :)