### PR TITLE
Fix mimikatz.py command_line length check

### DIFF
--- a/Payload_Type/Apollo/mythic/agent_functions/mimikatz.py
+++ b/Payload_Type/Apollo/mythic/agent_functions/mimikatz.py
@@ -15,7 +15,7 @@ class MimikatzArguments(TaskArguments):
         }
 
     async def parse_arguments(self):
-        if len(self.command_line > 0):
+        if len(self.command_line):
             if self.command_line[0] == "{":
                 self.load_args_from_json_string(self.command_line)
             else:


### PR DESCRIPTION
An improper check on the command_line length was resulting in the following mythic error when using the `mimikatz` command:

```
[-] Mythic error while creating/running create_tasking: 
'>' not supported between instances of 'str' and 'int'
```

