### PR TITLE
Share Functionality and Bug Squish

### DIFF
--- a/Payload_Type/Apollo/agent_code/Apollo/CommandModules/Download.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/CommandModules/Download.cs
@@ -34,9 +34,13 @@ namespace Apollo.CommandModules
         public static void Execute(Job job, Agent implant)
         {
             Task task = job.Task;
-            string filepath = task.parameters;
+            string filepath = task.parameters.Trim();
             string strReply;
             bool uploadResponse;
+            if (filepath[0] == '"' && filepath[filepath.Length - 1] == '"')
+                filepath = filepath.Substring(1, filepath.Length - 2);
+            else if (filepath[0] == '\'' && filepath[filepath.Length - 1] == '\'')
+                filepath = filepath.Substring(1, filepath.Length - 2);
             try // Try block for file upload task
             {
                 // Get file info to determine file size

--- a/Payload_Type/Apollo/agent_code/Apollo/CommandModules/Process.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/CommandModules/Process.cs
@@ -47,7 +47,10 @@ namespace Apollo.CommandModules
             if (job.Task.command == "shell")
             {
                 applicationName = "cmd.exe";
-                commandLine += String.Format("/c \"{0}\"", split[0]);
+                if (split[0].Contains(" "))
+                    commandLine += String.Format("/S /c \"\"{0}\"", split[0]);
+                else
+                    commandLine += String.Format("/S /c \"{0}", split[0]);
             } else
             {
                 applicationName = split[0];
@@ -83,7 +86,7 @@ namespace Apollo.CommandModules
                 }
                 if (commandLine != "")
                 {
-                    commandLine += String.Format(" {0}", subsequentArgs);
+                    commandLine += String.Format(" {0}\"", subsequentArgs);
                 }
                 else
                 {
@@ -124,10 +127,10 @@ namespace Apollo.CommandModules
             {
                 if (sacrificialProcess != null)
                 {
-                    job.SetError(String.Format("Error in executing \"{0}\" (PID: {1}). Reason: {2}", cmdString, sacrificialProcess.PID, ex.Message));
+                    job.SetError(String.Format("Error in executing '{0}' (PID: {1}). Reason: {2}", cmdString, sacrificialProcess.PID, ex.Message));
                 } else
                 {
-                    job.SetError(String.Format("Error in executing \"{0}\". Reason: {1}", cmdString, ex.Message));
+                    job.SetError(String.Format("Error in executing '{0}'. Reason: {1}", cmdString, ex.Message));
                 }
             }
 
@@ -135,7 +138,7 @@ namespace Apollo.CommandModules
             {
                 if (sacrificialProcess.ExitCode == 0 && sacrificialProcess.PID != 0)
                 {
-                    job.SetComplete(String.Format("\nProcess executed \"{0}\" with PID {1} and returned exit code {2}", cmdString, sacrificialProcess.PID, sacrificialProcess.ExitCode));
+                    job.SetComplete(String.Format("\nProcess executed '{0}' with PID {1} and returned exit code {2}", cmdString, sacrificialProcess.PID, sacrificialProcess.ExitCode));
                 } else
                 {
                     job.SetError($"Unknown error. Exit code: {sacrificialProcess.ExitCode} from PID: {sacrificialProcess.PID}");

--- a/Payload_Type/Apollo/agent_code/postbuild.ps1
+++ b/Payload_Type/Apollo/agent_code/postbuild.ps1
@@ -1,7 +1,7 @@
-$ServerPath = "\\Win-3dma5kl5ghd\c$\Users\windev\Development\mythic\Payload_Types\Apollo\agent_code\Apollo\bin\Debug\";
-$ClientPath = "\\COMPUTER01\c$\Users\windev\Development\mythic\Payload_Types\Apollo\agent_code\Apollo\bin\Debug\";
-$WorkstationPath = "\\WORKSTATION01\c$\Users\windev\Development\mythic\Payload_Types\Apollo\agent_code\Apollo\bin\Debug\";
-$localpath  = "C:\Users\windev\Development\mythic\Payload_Types\Apollo\agent_code\Apollo\bin\Debug\"
+$ServerPath = "\\Win-3dma5kl5ghd\c$\Users\windev\Development\Apollo\Payload_Type\Apollo\agent_code\Apollo\bin\Debug\";
+$ClientPath = "\\COMPUTER01\c$\Users\windev\Development\Apollo\Payload_Type\Apollo\agent_code\Apollo\bin\Debug\";
+$WorkstationPath = "\\WORKSTATION01\c$\Users\windev\Development\Apollo\Payload_Type\Apollo\agent_code\Apollo\bin\Debug\";
+$localpath  = "C:\Users\windev\Development\Apollo\Payload_Type\Apollo\agent_code\Apollo\bin\Debug\"
 
 
 Get-ChildItem $localpath | % {

--- a/Payload_Type/Apollo/mythic/agent_functions/cat.py
+++ b/Payload_Type/Apollo/mythic/agent_functions/cat.py
@@ -11,7 +11,10 @@ class CatArguments(TaskArguments):
     async def parse_arguments(self):
         if len(self.command_line) == 0:
             raise Exception("Require file path to retrieve contents for.\n\tUsage: {}".format(CatCommand.help_cmd))
-
+        if self.command_line[0] == '"' and self.command_line[-1] == '"':
+            self.command_line = self.command_line[1:-1]
+        elif self.command_line[0] == "'" and self.command_line[-1] == "'":
+            self.command_line = self.command_line[1:-1]
 
 class CatCommand(CommandBase):
     cmd = "cat"

--- a/Payload_Type/Apollo/mythic/agent_functions/cd.py
+++ b/Payload_Type/Apollo/mythic/agent_functions/cd.py
@@ -11,6 +11,10 @@ class CdArguments(TaskArguments):
     async def parse_arguments(self):
         if len(self.command_line) == 0:
             raise Exception("Require path to change directory to.\nUsage:\n\t{}".format(CdCommand.help_cmd))
+        if self.command_line[0] == '"' and self.command_line[-1] == '"':
+            self.command_line = self.command_line[1:-1]
+        elif self.command_line[0] == "'" and self.command_line[-1] == "'":
+            self.command_line = self.command_line[1:-1]
 
 
 class CdCommand(CommandBase):

--- a/Payload_Type/Apollo/mythic/agent_functions/download.py
+++ b/Payload_Type/Apollo/mythic/agent_functions/download.py
@@ -11,7 +11,10 @@ class DownloadArguments(TaskArguments):
     async def parse_arguments(self):
         if len(self.command_line) == 0:
             raise Exception("Require a path to download.\n\tUsage: {}".format(DownloadCommand.help_cmd))
-
+        if self.command_line[0] == '"' and self.command_line[-1] == '"':
+            self.command_line = self.command_line[1:-1]
+        elif self.command_line[0] == "'" and self.command_line[-1] == "'":
+            self.command_line = self.command_line[1:-1]
 
 class DownloadCommand(CommandBase):
     cmd = "download"

--- a/Payload_Type/Apollo/mythic/agent_functions/ls.py
+++ b/Payload_Type/Apollo/mythic/agent_functions/ls.py
@@ -6,15 +6,12 @@ class LsArguments(TaskArguments):
 
     def __init__(self, command_line):
         super().__init__(command_line)
-        self.args = {
-            "path": CommandParameter(name="Path", type=ParameterType.String, description="Path to list files from.", required=False),
-            "host": CommandParameter(name="Host", type=ParameterType.String, description="Host to query files from the given path.", required=False),
-        }
+        self.args = {}
 
     async def parse_arguments(self):
         if len(self.command_line) > 0:
+            # We'll never enter this control flow
             if self.command_line[0] == '{':
-                self.load_args_from_json_string(self.command_line)
                 temp_json = json.loads(self.command_line)
                 host = ""
                 path = temp_json['path']

--- a/Payload_Type/Apollo/mythic/agent_functions/mkdir.py
+++ b/Payload_Type/Apollo/mythic/agent_functions/mkdir.py
@@ -11,6 +11,10 @@ class MkdirArguments(TaskArguments):
     async def parse_arguments(self):
         if len(self.command_line) == 0:
             raise Exception("No path given.\n\tUsage: {}".format(MkdirCommand.help_cmd))
+        if self.command_line[0] == '"' and self.command_line[-1] == '"':
+            self.command_line = self.command_line[1:-1]
+        elif self.command_line[0] == "'" and self.command_line[-1] == "'":
+            self.command_line = self.command_line[1:-1]
         pass
 
 

--- a/Payload_Type/Apollo/mythic/agent_functions/rm.py
+++ b/Payload_Type/Apollo/mythic/agent_functions/rm.py
@@ -25,6 +25,14 @@ class RmArguments(TaskArguments):
                 self.add_arg("path", self.command_line)
         else:
             raise Exception("rm requires a path to remove.\n\tUsage: {}".format(RmCommand.help_cmd))
+        path = self.get_arg("path")
+        if path != "" and path != None:
+            path = path.strip()
+            if path[0] == '"' and path[-1] == '"':
+                path = path[1:-1]
+            elif path[0] == "'" and path[-1] == "'":
+                path = path[1:-1]
+            self.add_arg("path", path)
 
 
 class RmCommand(CommandBase):

--- a/Payload_Type/Apollo/mythic/agent_functions/upload.py
+++ b/Payload_Type/Apollo/mythic/agent_functions/upload.py
@@ -21,6 +21,14 @@ class UploadArguments(TaskArguments):
         if self.command_line[0] != "{":
             raise Exception("Require JSON blob, but got raw command line.")
         self.load_args_from_json_string(self.command_line)
+        remote_path = self.get_arg("remote_path")
+        if remote_path != "" and remote_path != None:
+            remote_path = remote_path.strip()
+            if remote_path[0] == '"' and remote_path[-1] == '"':
+                remote_path = remote_path[1:-1]
+            elif remote_path[0] == "'" and remote_path[-1] == "'":
+                remote_path = remote_path[1:-1]
+            self.add_arg("remote_path", remote_path)
         pass
 
 


### PR DESCRIPTION
- `net_shares` now populates Mythic's filebrowser.
- Path parsing with quotes has been fixed (hopefully) for a variety of commands.
- `shell` now does `cmd.exe /S /c` to enforce good quotations.
- Reverted change to `ls` that made it accept JSON arguments 