### PR TITLE
Adding the integrity level to the output of the "whoami" command

### DIFF
--- a/Payload_Type/Apollo/agent_code/Apollo/CommandModules/TokenManager.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/CommandModules/TokenManager.cs
@@ -74,8 +74,8 @@ namespace Apollo.CommandModules
 #endif
 #if WHOAMI
                 case "whoami":
-                    string message = "{0} for local operations, {1} for remote operations.";
-                    message = string.Format(message, CredentialManager.CurrentIdentity.Name, CredentialManager.GetCurrentUsername());
+                    string message = "{0} for local operations ({1} integrity), {2} for remote operations.";
+                    message = string.Format(message, CredentialManager.CurrentIdentity.Name, CredentialManager.GetIntegrityLevelAsString().ToLower(), CredentialManager.GetCurrentUsername());
                     job.SetComplete(message);
                     break;
 #endif

--- a/Payload_Type/Apollo/agent_code/Apollo/Credentials/CredentialManager.cs
+++ b/Payload_Type/Apollo/agent_code/Apollo/Credentials/CredentialManager.cs
@@ -186,6 +186,26 @@ namespace Apollo.Credentials
             return dwRet;
         }
 
+        internal static string GetIntegrityLevelAsString()
+        {
+            if (!initialized)
+                return "";
+            switch (IntegrityLevel)
+            {
+                case 0:
+                case 1:
+                    return "Low";
+                case 2:
+                    return "Medium";
+                case 3:
+                    return "High";
+                case 4:
+                    return "System";
+                default: // We should never hit this
+                    return "Unknown";
+            }
+        }
+
         private static IntPtr GetCurrentThread()
         {
             DebugWriteLine("Getting current thread...");


### PR DESCRIPTION
This PR adds the integrity level of the current process when running `whoami`. The added function to return the human-readable version builds on top of the existing function used for returning the IL to Mythic.