### PR TITLE
Builder.py Not Populating C2 Profiles

### DIFF
--- a/Payload_Type/apollo/mythic/agent_functions/builder.py
+++ b/Payload_Type/apollo/mythic/agent_functions/builder.py
@@ -17,9 +17,7 @@ class Apollo(PayloadType):
     wrapper = False
     wrapped_payloads = ["service_wrapper"]
     note = """
-A fully featured .NET 4.0 compatible training agent.
-
-Version: {}
+A fully featured .NET 4.0 compatible training agent. Version: {}
     """.format(version)
     supports_dynamic_loading = True
     build_parameters = {


### PR DESCRIPTION
An error in builder.py was identified when migrating to the latest version of Mythic. This PR ensures that all requisite C2 parameters specified by the user are stamped in at build time. Closes #41 