### PR TITLE
Register file wrappers

### DIFF
--- a/Payload_Type/apollo/mythic/agent_functions/blockdlls.py
+++ b/Payload_Type/apollo/mythic/agent_functions/blockdlls.py
@@ -44,7 +44,7 @@ class BlockDllsCommand(CommandBase):
     needs_admin = False
     help_cmd = "blockdlls [on|off]"
     description = "Block non-Microsoft DLLs from loading into sacrificial processes."
-    version = 1
+    version = 2
     is_exit = False
     is_file_browse = False
     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/golden_ticket.py
+++ b/Payload_Type/apollo/mythic/agent_functions/golden_ticket.py
@@ -97,7 +97,7 @@
 #     needs_admin = True
 #     help_cmd = "golden_ticket (modal popup)"
 #     description = "Forge a golden/silver ticket using Mimikatz."
-#     version = 1
+#     version = 2
 #     is_exit = False
 #     is_file_browse = False
 #     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/load.py
+++ b/Payload_Type/apollo/mythic/agent_functions/load.py
@@ -62,7 +62,7 @@ class LoadCommand(CommandBase):
     needs_admin = False
     help_cmd = "load [cmd1] [cmd2] [...]"
     description = 'Load one or more new commands into the agent.'
-    version = 1
+    version = 2
     is_exit = False
     is_file_browse = False
     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/mv.py
+++ b/Payload_Type/apollo/mythic/agent_functions/mv.py
@@ -64,7 +64,7 @@ class MvCommand(CommandBase):
     needs_admin = False
     help_cmd = "mv [source] [dest]"
     description = "Move a file from source to destination."
-    version = 1
+    version = 2
     is_exit = False
     is_file_browse = False
     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/net_dclist.py
+++ b/Payload_Type/apollo/mythic/agent_functions/net_dclist.py
@@ -17,7 +17,7 @@ class NetDCListCommand(CommandBase):
     needs_admin = False
     help_cmd = "net_dclist [domain]"
     description = "Get domain controllers belonging to [domain]. Defaults to current domain."
-    version = 1
+    version = 2
     is_exit = False
     is_file_browse = False
     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/powershell_import.py
+++ b/Payload_Type/apollo/mythic/agent_functions/powershell_import.py
@@ -1,0 +1,58 @@
+from mythic_payloadtype_container.MythicCommandBase import *
+import json
+from mythic_payloadtype_container.MythicRPC import *
+import base64
+import sys
+
+class PowerShellImportArguments(TaskArguments):
+
+    def __init__(self, command_line, **kwargs):
+        super().__init__(command_line, **kwargs)
+        self.args = [
+            CommandParameter(
+                name="file",
+                cli_name="File", 
+                display_name="File",
+                type=ParameterType.File)
+        ]
+
+    async def parse_arguments(self):
+        if (self.command_line[0] != "{"):
+            raise Exception("Inject requires JSON parameters and not raw command line.")
+        self.load_args_from_json_string(self.command_line)
+
+class PowerShellImportCommand(CommandBase):
+    cmd = "powershell_import"
+    attributes=CommandAttributes(
+        dependencies=["register_file"]
+    )
+    needs_admin = False
+    help_cmd = "powershell_import (modal popup)"
+    description = "Import a new .ps1 into the agent cache."
+    version = 2
+    is_exit = False
+    is_file_browse = False
+    is_process_list = False
+    is_download_file = False
+    is_upload_file = False
+    is_remove_file = False
+    script_only = True
+    author = "@djhohnstein"
+    argument_class = PowerShellImportArguments
+    attackmapping = []
+
+
+    async def psimport_callback(self, task: MythicTask, subtask: dict = None, subtask_group_name: str = None) -> MythicTask:
+        task.status = MythicStatus.Completed
+        return task
+
+    async def create_tasking(self, task: MythicTask) -> MythicTask:
+        response = await MythicRPC().execute("create_subtask", parent_task_id=task.id,
+                        command="register_file", params_dict={"file": task.args.get_arg("file")},
+                        subtask_callback_function="psimport_callback")
+        if response.status != MythicStatus.Success:
+            raise Exception("Failed to create subtask: {}".format(response.message))
+        return task
+
+    async def process_response(self, response: AgentResponse):
+        pass

--- a/Payload_Type/apollo/mythic/agent_functions/ppid.py
+++ b/Payload_Type/apollo/mythic/agent_functions/ppid.py
@@ -35,7 +35,7 @@ class PpidCommand(CommandBase):
     needs_admin = False
     help_cmd = "ppid [pid]"
     description = "Change the parent process for post-ex jobs by the specified pid."
-    version = 1
+    version = 2
     is_exit = False
     is_file_browse = False
     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/reg_query.py
+++ b/Payload_Type/apollo/mythic/agent_functions/reg_query.py
@@ -57,7 +57,7 @@ class RegQuery(CommandBase):
     needs_admin = False
     help_cmd = "reg_query [key]"
     description = "Query registry keys and values for an associated registry key [key]."
-    version = 1
+    version = 2
     is_exit = False
     is_file_browse = False
     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/register_assembly.py
+++ b/Payload_Type/apollo/mythic/agent_functions/register_assembly.py
@@ -1,0 +1,58 @@
+from mythic_payloadtype_container.MythicCommandBase import *
+import json
+from mythic_payloadtype_container.MythicRPC import *
+import base64
+import sys
+
+class RegisterAssemblyArguments(TaskArguments):
+
+    def __init__(self, command_line, **kwargs):
+        super().__init__(command_line, **kwargs)
+        self.args = [
+            CommandParameter(
+                name="file",
+                cli_name="File", 
+                display_name="File",
+                type=ParameterType.File)
+        ]
+
+    async def parse_arguments(self):
+        if (self.command_line[0] != "{"):
+            raise Exception("Inject requires JSON parameters and not raw command line.")
+        self.load_args_from_json_string(self.command_line)
+
+class RegisterAssemblyCommand(CommandBase):
+    cmd = "register_assembly"
+    attributes=CommandAttributes(
+        dependencies=["register_file"]
+    )
+    needs_admin = False
+    help_cmd = "register_assembly (modal popup)"
+    description = "Import a new Assembly into the agent cache."
+    version = 2
+    is_exit = False
+    is_file_browse = False
+    is_process_list = False
+    is_download_file = False
+    is_upload_file = False
+    is_remove_file = False
+    script_only = True
+    author = "@djhohnstein"
+    argument_class = RegisterAssemblyArguments
+    attackmapping = []
+
+
+    async def registerasm_callback(self, task: MythicTask, subtask: dict = None, subtask_group_name: str = None) -> MythicTask:
+        task.status = MythicStatus.Completed
+        return task
+
+    async def create_tasking(self, task: MythicTask) -> MythicTask:
+        response = await MythicRPC().execute("create_subtask", parent_task_id=task.id,
+                        command="register_file", params_dict={"file": task.args.get_arg("file")},
+                        subtask_callback_function="registerasm_callback")
+        if response.status != MythicStatus.Success:
+            raise Exception("Failed to create subtask: {}".format(response.message))
+        return task
+
+    async def process_response(self, response: AgentResponse):
+        pass

--- a/Payload_Type/apollo/mythic/agent_functions/rm.py
+++ b/Payload_Type/apollo/mythic/agent_functions/rm.py
@@ -60,7 +60,7 @@ class RmCommand(CommandBase):
     needs_admin = False
     help_cmd = "rm [path]"
     description = "Delete a file specified by [path]"
-    version = 1
+    version = 2
     is_exit = False
     is_file_browse = False
     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/sc.py
+++ b/Payload_Type/apollo/mythic/agent_functions/sc.py
@@ -198,7 +198,7 @@ class ScCommand(CommandBase):
     needs_admin = False
     help_cmd = "sc"
     description = "Service control manager wrapper function"
-    version = 1
+    version = 2
     is_exit = False
     is_file_browse = False
     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/socks.py
+++ b/Payload_Type/apollo/mythic/agent_functions/socks.py
@@ -33,7 +33,7 @@ class SocksCommand(CommandBase):
     needs_admin = False
     help_cmd = "socks [port number]"
     description = "Enable SOCKS 5 compliant proxy to send data to the target network. Compatible with proxychains and proxychains4."
-    version = 1
+    version = 2
     script_only = True
     author = "@djhohnstein"
     argument_class = SocksArguments

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ net_localgroup | `net_localgroup [computer]` | Retrieve local groups known by a 
 net_shares | `net_shares [-Computer [computer]]` | Show shares of a remote PC.
 powerpick | `powerpick -Command [command]` | Executes PowerShell in a sacrificial process.
 powershell | `powershell -Command [command]` | Executes PowerShell in your currently running process.
+powershell_import | `powershell_import` | Register a new .ps1 file to be used in other PowerShell jobs
 ppid | `ppid -PID [pid_integer]` | Set the PPID of sacrificial jobs to the specified PID.
 printspoofer | `printspoofer -Command [command]` | Execute a command in SYSTEM integrity so long as you have SeImpersonate privileges.
 ps | `ps` | List process information.
@@ -69,6 +70,7 @@ pth | `pth -Domain [domain] -User [username] -NTLM [ntlm_hash] [-AES128 [aes128_
 pwd | `pwd` | Print working directory.
 reg_query | `reg_query -Hive [HKCU:\\|HKU:\\|HKLM:\\|HKCR:\] [-Key [keyname]]` | Query all subkeys of the specified registry path. Needs to be of the format `HKCU:\`, `HKLM:\`, or `HKCR:\`.
 reg_write_value | `reg_write_value -Hive [HKCU:\|HKU:\|HKLM:\|HKCR:\] -Key [keyname] [-Name [value_name] -Value [value_value]]` | Write specified values to the registry keys.
+register_assembly | `register_assembly` | Register a .NET assembly with the agent to be used in .NET post-exploitation activities
 register_file | `register_file` | Register a file to the agent's file cache. Used to store assemblies, executables, and PowerShell scripts.
 rev2self | `rev2self` | Revert the access token to the original access token.
 rm | `rm -Path [path] [-Host [hostname] -File [filename]]` | Remove a file specified by `[path]`. Alternatively, if `-File` is provided, `-Path` will be used as the directory, and `-File` will be the filename.

--- a/documentation-payload/apollo/commands/_index.md
+++ b/documentation-payload/apollo/commands/_index.md
@@ -29,10 +29,12 @@ pre = "<b>2. </b>"
     * [inline_assembly](/agents/apollo/commands/inline_assembly/)
     * [execute_assembly](/agents/apollo/commands/execute_assembly/)
     * [assembly_inject](/agents/apollo/commands/assembly_inject/)
+    * [register_assembly](/agents/apollo/commands/register_assembly/)
 - PowerShell Commands
     * [powershell](/agents/apollo/commands/powershell/)
     * [psinject](/agents/apollo/commands/psinject/)
     * [powerpick](/agents/apollo/commands/powerpick/)
+    * [powershell_import](/agents/apollo/commands/powershell_import/)
 - File Operations
     * [upload](/agents/apollo/commands/upload/)
     * [download](/agents/apollo/commands/download/)

--- a/documentation-payload/apollo/commands/powershell_import.md
+++ b/documentation-payload/apollo/commands/powershell_import.md
@@ -1,0 +1,19 @@
++++
+title = "powershell_import"
+chapter = false
+weight = 103
+hidden = false
++++
+
+## Summary
+Cache a .ps1 file to be used in other post-exploitation jobs. This command is a thin wrapper around the [`register_file`](/agents/apollo/commands/register_file/) command.
+
+By default, these files are cached in the agent using both AES256 at rest, and decrypted only for task execution.
+
+### Arguments (Popup)
+#### File
+The file to cache in the agent for post-ex jobs.
+
+## MITRE ATT&CK Mapping
+
+- T1547

--- a/documentation-payload/apollo/commands/register_assembly.md
+++ b/documentation-payload/apollo/commands/register_assembly.md
@@ -1,0 +1,19 @@
++++
+title = "register_assembly"
+chapter = false
+weight = 103
+hidden = false
++++
+
+## Summary
+Cache a .NET assembly to be used in other post-exploitation jobs. This command is a thin wrapper around the [`register_file`](/agents/apollo/commands/register_file/) command.
+
+By default, these files are cached in the agent using both AES256 at rest, and decrypted only for task execution.
+
+### Arguments (Popup)
+#### File
+The file to cache in the agent for post-ex jobs.
+
+## MITRE ATT&CK Mapping
+
+- T1547


### PR DESCRIPTION
Added the following wrappers to `register_file` to avoid confusion to users from 1.X:
- `powershell_import`
- `register_assembly`