### PR TITLE
Language localization

### DIFF
--- a/Payload_Type/apollo/agent_code/Apollo/Config.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Config.cs
@@ -116,7 +116,7 @@ namespace Apollo
         public static string StagingRSAPrivateKey = "LbFpMoimB+aLx1pq0IqXJ1MQ4KIiGdp0LWju5jUhZRg=";
 #endif
 #if HTTP
-        public static string PayloadUUID = "704f7dac-6122-4964-aebe-1100743dffbb";
+        public static string PayloadUUID = "d3c67157-6842-41eb-bb16-d0eb79c207f7";
 #elif SMB
         public static string PayloadUUID = "869c4909-30eb-4a90-99b2-874dae07a0a8";
 #elif TCP

--- a/Payload_Type/apollo/agent_code/ApolloInterop/Classes/Pipes/AsyncNamedPipeServer.cs
+++ b/Payload_Type/apollo/agent_code/ApolloInterop/Classes/Pipes/AsyncNamedPipeServer.cs
@@ -37,8 +37,8 @@ namespace ApolloInterop.Classes
             {
                 _pipeSecurity = new PipeSecurity();
                 PipeAccessRule multipleInstances = new PipeAccessRule(WindowsIdentity.GetCurrent().Name, PipeAccessRights.CreateNewInstance, AccessControlType.Allow);
-                PipeAccessRule everyoneAllowedRule = new PipeAccessRule("Everyone", PipeAccessRights.ReadWrite, AccessControlType.Allow);
-                PipeAccessRule networkAllowRule = new PipeAccessRule("Network", PipeAccessRights.ReadWrite, AccessControlType.Allow);
+                PipeAccessRule everyoneAllowedRule = new PipeAccessRule(new SecurityIdentifier(WellKnownSidType.WorldSid, null), PipeAccessRights.ReadWrite, AccessControlType.Allow);
+                PipeAccessRule networkAllowRule = new PipeAccessRule(new SecurityIdentifier(WellKnownSidType.NetworkSid, null), PipeAccessRights.ReadWrite, AccessControlType.Allow);
                 _pipeSecurity.AddAccessRule(multipleInstances);
                 _pipeSecurity.AddAccessRule(everyoneAllowedRule);
                 _pipeSecurity.AddAccessRule(networkAllowRule);

--- a/Payload_Type/apollo/mythic/agent_functions/builder.py
+++ b/Payload_Type/apollo/mythic/agent_functions/builder.py
@@ -14,7 +14,7 @@ class Apollo(PayloadType):
     supported_os = [
         SupportedOS.Windows
     ]
-    version = "2.0.1"
+    version = "2.0.2"
     wrapper = False
     wrapped_payloads = ["service_wrapper"]
     note = """


### PR DESCRIPTION
This commit solves an issue with the pipe security of named pipes being instantiated by their short-hand English name (such as Everyone) over their SID identifiers. Doing the former would crash processes on non-English machines, as they would fail to resolve Everyone or Network to account identifiers. Using SIDs resolves these application crashes.