### PR TITLE
Updating mimikatz.md

### DIFF
--- a/Payload_Type/apollo/agent_code/Apollo/Program.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Program.cs
@@ -37,7 +37,7 @@ namespace Apollo
         private static bool _completed;
         private static Action<object> _flushMessages;
 
-        static void Main(string[] args)
+        public static void Main(string[] args)
         {
             //_sendAction = (object p) =>
             //{

--- a/Payload_Type/apollo/mythic/agent_functions/assembly_inject.py
+++ b/Payload_Type/apollo/mythic/agent_functions/assembly_inject.py
@@ -25,7 +25,7 @@ class AssemblyInjectArguments(TaskArguments):
                 parameter_group_info = [
                     ParameterGroupInfo(
                         required=True,
-                        ui_position=0,
+                        ui_position=1,
                         group_name="Default",
                     )
                 ]),
@@ -39,7 +39,7 @@ class AssemblyInjectArguments(TaskArguments):
                 parameter_group_info = [
                     ParameterGroupInfo(
                         required=True,
-                        ui_position=1,
+                        ui_position=2,
                         group_name="Default",
                     ),
                 ]),
@@ -52,7 +52,7 @@ class AssemblyInjectArguments(TaskArguments):
                 parameter_group_info = [
                     ParameterGroupInfo(
                         required=False,
-                        ui_position=2,
+                        ui_position=3,
                         group_name="Default",
                     ),
                 ]),
@@ -97,7 +97,7 @@ class AssemblyInjectCommand(CommandBase):
     needs_admin = False
     help_cmd = "assembly_inject [pid] [assembly] [args]"
     description = "Inject the unmanaged assembly loader into a remote process. The loader will then execute the .NET binary in the context of the injected process."
-    version = 2
+    version = 3
     is_exit = False
     is_file_browse = False
     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/blockdlls.py
+++ b/Payload_Type/apollo/mythic/agent_functions/blockdlls.py
@@ -17,7 +17,7 @@ class BlockDllsArguments(TaskArguments):
                 parameter_group_info=[
                     ParameterGroupInfo(
                         required=False,
-                        ui_position=0,
+                        ui_position=1,
                         group_name="Default",
                     )
                 ]
@@ -44,7 +44,7 @@ class BlockDllsCommand(CommandBase):
     needs_admin = False
     help_cmd = "blockdlls [on|off]"
     description = "Block non-Microsoft DLLs from loading into sacrificial processes."
-    version = 2
+    version = 3
     is_exit = False
     is_file_browse = False
     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/dcsync.py
+++ b/Payload_Type/apollo/mythic/agent_functions/dcsync.py
@@ -21,7 +21,7 @@ class DcSyncArguments(TaskArguments):
                 description="Domain to sync credentials from.",
                 parameter_group_info=[
                     ParameterGroupInfo(
-                        ui_position=0,
+                        ui_position=1,
                         required=True
                     )
                 ]),
@@ -34,7 +34,7 @@ class DcSyncArguments(TaskArguments):
                 description="Username to sync. Defaults to all.",
                 parameter_group_info=[
                     ParameterGroupInfo(
-                        ui_position=1,
+                        ui_position=2,
                         required=False
                     )
                 ]),
@@ -46,7 +46,7 @@ class DcSyncArguments(TaskArguments):
                 description="Domain controller to sync credential material from.",
                 parameter_group_info=[
                     ParameterGroupInfo(
-                        ui_position=2,
+                        ui_position=3,
                         required=False
                     )
                 ]),
@@ -83,7 +83,7 @@ class DcSyncCommand(CommandBase):
     needs_admin = False
     help_cmd = "dcsync -Domain [domain] -User [user]"
     description = "Sync a user's Kerberos keys to the local machine."
-    version = 2
+    version = 3
     is_exit = False
     is_file_browse = False
     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/download.py
+++ b/Payload_Type/apollo/mythic/agent_functions/download.py
@@ -17,7 +17,7 @@ class DownloadArguments(TaskArguments):
                     ParameterGroupInfo(
                         required=True,
                         group_name="Default",
-                        ui_position=0
+                        ui_position=1
                     )
                 ]),
             CommandParameter(
@@ -30,7 +30,7 @@ class DownloadArguments(TaskArguments):
                     ParameterGroupInfo(
                         required=False,
                         group_name="Default",
-                        ui_position=1
+                        ui_position=2
                     ),
                 ]),
         ]
@@ -79,7 +79,7 @@ class DownloadCommand(CommandBase):
     needs_admin = False
     help_cmd = "download -Path [path/to/file] [-Host [hostname]]"
     description = "Download a file off the target system."
-    version = 2
+    version = 3
     is_exit = False
     is_file_browse = False
     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/execute_assembly.py
+++ b/Payload_Type/apollo/mythic/agent_functions/execute_assembly.py
@@ -28,7 +28,7 @@ class ExecuteAssemblyArguments(TaskArguments):
                     ParameterGroupInfo(
                         required=True,
                         group_name="Default",
-                        ui_position=0
+                        ui_position=1
                     )
                 ]),
             CommandParameter(
@@ -41,7 +41,7 @@ class ExecuteAssemblyArguments(TaskArguments):
                     ParameterGroupInfo(
                         required=False,
                         group_name="Default",
-                        ui_position=1
+                        ui_position=2
                     ),
                 ]),
         ]
@@ -80,7 +80,7 @@ class ExecuteAssemblyCommand(CommandBase):
     needs_admin = False
     help_cmd = "execute_assembly [Assembly.exe] [args]"
     description = "Executes a .NET assembly with the specified arguments. This assembly must first be known by the agent using the `register_assembly` command."
-    version = 2
+    version = 3
     is_exit = False
     is_file_browse = False
     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/execute_pe.py
+++ b/Payload_Type/apollo/mythic/agent_functions/execute_pe.py
@@ -29,6 +29,13 @@ class ExecutePEArguments(TaskArguments):
                 type=ParameterType.ChooseOne,
                 dynamic_query_function=self.get_files,
                 description="PE to execute (e.g., mimikatz.exe).",
+                parameter_group_info = [
+                    ParameterGroupInfo(
+                        required=True,
+                        group_name="Default",
+                        ui_position=1,
+                    ),
+                ],
             ),
             CommandParameter(
                 name="pe_arguments",
@@ -40,6 +47,7 @@ class ExecutePEArguments(TaskArguments):
                     ParameterGroupInfo(
                         required=False,
                         group_name="Default",
+                        ui_position=2
                     ),
                 ]),
         ]
@@ -77,7 +85,7 @@ class ExecutePECommand(CommandBase):
     needs_admin = False
     help_cmd = "execute_pe [PE.exe] [args]"
     description = "Executes a .NET assembly with the specified arguments. This assembly must first be known by the agent using the `register_assembly` command."
-    version = 2
+    version = 3
     is_exit = False
     is_file_browse = False
     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/inline_assembly.py
+++ b/Payload_Type/apollo/mythic/agent_functions/inline_assembly.py
@@ -24,7 +24,14 @@ class InlineAssemblyArguments(TaskArguments):
                 display_name = "Assembly",
                 type=ParameterType.ChooseOne,
                 dynamic_query_function=self.get_files,
-                description="Assembly to execute (e.g., Seatbelt.exe).",),
+                description="Assembly to execute (e.g., Seatbelt.exe).",
+                parameter_group_info = [
+                    ParameterGroupInfo(
+                        required=True,
+                        group_name="Default",
+                        ui_position=1
+                    ),
+                ]),
             CommandParameter(
                 name="assembly_arguments",
                 cli_name="Arguments",
@@ -35,6 +42,7 @@ class InlineAssemblyArguments(TaskArguments):
                     ParameterGroupInfo(
                         required=False,
                         group_name="Default",
+                        ui_position=2
                     ),
                 ]),
         ]
@@ -72,7 +80,7 @@ class InlineAssemblyCommand(CommandBase):
     needs_admin = False
     help_cmd = "inline_assembly [Assembly.exe] [args]"
     description = "Executes a .NET assembly with the specified arguments in a disposable AppDomain. This assembly must first be known by the agent using the `register_assembly` command."
-    version = 2
+    version = 3
     is_exit = False
     is_file_browse = False
     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/ls.py
+++ b/Payload_Type/apollo/mythic/agent_functions/ls.py
@@ -30,7 +30,7 @@ class LsArguments(TaskArguments):
                     ParameterGroupInfo(
                         required=False,
                         group_name="Default",
-                        ui_position=0
+                        ui_position=2
                     ),
                 ]),
         ]
@@ -92,7 +92,7 @@ class LsCommand(CommandBase):
     needs_admin = False
     help_cmd = "ls [path]"
     description = "List files and folders in a specified directory (defaults to your current working directory.)"
-    version = 2
+    version = 3
     is_exit = False
     supported_ui_features = ["file_browser:list"]
     is_process_list = False

--- a/Payload_Type/apollo/mythic/agent_functions/pth.py
+++ b/Payload_Type/apollo/mythic/agent_functions/pth.py
@@ -21,7 +21,7 @@ class PthArguments(TaskArguments):
                 description="Domain associated with user.",
                 parameter_group_info=[
                     ParameterGroupInfo(
-                        ui_position=0,
+                        ui_position=1,
                         required=True
                     )
                 ]),
@@ -33,7 +33,7 @@ class PthArguments(TaskArguments):
                 description="Username associated with the NTLM hash.",
                 parameter_group_info=[
                     ParameterGroupInfo(
-                        ui_position=1,
+                        ui_position=2,
                         required=True
                     )
                 ]),
@@ -45,7 +45,7 @@ class PthArguments(TaskArguments):
                 description="User's NTLM hash.",
                 parameter_group_info=[
                     ParameterGroupInfo(
-                        ui_position=2,
+                        ui_position=3,
                         required=True
                     )
                 ]),
@@ -57,7 +57,7 @@ class PthArguments(TaskArguments):
                 description="AES128 key of user. Used for over pass the hash.",
                 parameter_group_info=[
                     ParameterGroupInfo(
-                        ui_position=3,
+                        ui_position=4,
                         required=False
                     )
                 ]),
@@ -69,7 +69,7 @@ class PthArguments(TaskArguments):
                 description="AES256 key of user. Used for over pass the hash.",
                 parameter_group_info=[
                     ParameterGroupInfo(
-                        ui_position=4,
+                        ui_position=5,
                         required=False
                     )
                 ]),
@@ -81,13 +81,13 @@ class PthArguments(TaskArguments):
                 description="The process to launch under the specified credentials.",
                 parameter_group_info=[
                     ParameterGroupInfo(
-                        ui_position=5,
+                        ui_position=6,
                         required=False
                     ),
                     ParameterGroupInfo(
                         required=False,
                         group_name="SavedCredentials",
-                        ui_position=1
+                        ui_position=2
                     )
                 ]),
         
@@ -99,7 +99,7 @@ class PthArguments(TaskArguments):
                 description="Username and hash of the user to impersonate",
                 parameter_group_info=[
                     ParameterGroupInfo(
-                        ui_position=0,
+                        ui_position=1,
                         required=True,
                         group_name="SavedCredentials"
                     )
@@ -153,7 +153,7 @@ class PthCommand(CommandBase):
     needs_admin = False
     help_cmd = "pth -Domain [domain] -User [user] -NTLM [ntlm] [-AES128 [aes128] -AES256 [aes256] -Run [cmd.exe]]"
     description = "Spawn a new process using the specified domain user's credential material."
-    version = 2
+    version = 3
     is_exit = False
     is_file_browse = False
     is_process_list = False

--- a/documentation-payload/apollo/commands/mimikatz.md
+++ b/documentation-payload/apollo/commands/mimikatz.md
@@ -16,6 +16,8 @@ Execute one or more mimikatz commands.
 #### Command
 The command you would like mimikatz to run. Some commands require certain privileges and may need the `token::elevate` Mimikatz command or the builtin equivalent [`getprivs`](/agents/apollo/commands/getprivs/) to be executed first.
 
+The `mimikatz` binary takes space-separated commands. For example, if you wanted to ensure your token had the correct privileges before dumping LSASS, you could do `mimikatz token::elevate sekurlsa::logonpasswords` to first elevate your token before running `logonpasswords`. Due to this space-separated command list, if you wish to run a command that has arguments (or spaces in its command name), you'll need to encapsulate that command in _escaped_ quotes. 
+
 ## Usage
 ```
 mimikatz -Command [command]
@@ -25,7 +27,9 @@ Example
 ```
 mimikatz sekurlsa::logonpasswords
 mimikatz -Command sekurlsa::logonpasswords
-# in case several commands should be executed don't forget to escape the quotes
+
+# Running one or more commands with spaces in the command name
+
 mimikatz -Command \"privilege::debug\" \"sekurlsa::pth /domain:DOMAIN /user:USERNAME /ntlm:HASH\" exit
 ```
 

--- a/documentation-payload/apollo/commands/mimikatz.md
+++ b/documentation-payload/apollo/commands/mimikatz.md
@@ -33,6 +33,9 @@ mimikatz -Command sekurlsa::logonpasswords
 mimikatz -Command \"privilege::debug\" \"sekurlsa::pth /domain:DOMAIN /user:USERNAME /ntlm:HASH\" exit
 ```
 
+## See Also
+- [dcsync](/agents/apollo/commands/dcsync/)
+- [pth](/agents/apollo/commands/dcsync/)
 
 ## MITRE ATT&CK Mapping
 


### PR DESCRIPTION
Documentation for `mimikatz` did not include how to properly escape command strings due to the argv parsing in the `mimikatz` binary. Documentation now includes how to escape commands and includes resources to `pth` and `dcsync`