### PR TITLE
Proposed fix for TCP profile unlink bug

### DIFF
--- a/Payload_Type/apollo/agent_code/Apollo/Peers/TCP/TCPPeer.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Peers/TCP/TCPPeer.cs
@@ -16,6 +16,7 @@ using System.Threading;
 using TTasks = System.Threading.Tasks;
 using ApolloInterop.Enums.ApolloEnums;
 using System.Net.Sockets;
+using ApolloInterop.Classes.Api;
 using ApolloInterop.Classes.Core;
 
 namespace Apollo.Peers.TCP
@@ -27,6 +28,10 @@ namespace Apollo.Peers.TCP
         private TTasks.Task _sendTask;
         private bool _connected = false;
         private string _partialData = "";
+        private IntPtr _socketHandle = IntPtr.Zero;
+        private delegate void CloseHandle(IntPtr handle);
+        private CloseHandle _pCloseHandle;
+        
         public TCPPeer(IAgent agent, PeerInformation info) : base(agent, info)
         {
             C2ProfileName = "tcp";
@@ -80,6 +85,7 @@ namespace Apollo.Peers.TCP
             _sendTask.Start();
             _connected = true;
             _previouslyConnected = true;
+            _socketHandle = args.Client.Client.Handle;
         }
 
         public void OnDisconnect(object sender, TcpMessageEventArgs args)
@@ -184,6 +190,8 @@ namespace Apollo.Peers.TCP
         public override void Stop()
         {
             _cts.Cancel();
+            _pCloseHandle = _agent.GetApi().GetLibraryFunction<CloseHandle>(Library.KERNEL32, "CloseHandle");
+            _pCloseHandle(_socketHandle);
             _sendTask.Wait();
         }
     }


### PR DESCRIPTION
This pull request addresses issue #105  where established connections were not being properly closed when the `unlink` command was executed. The issue appears to be in TCPPeer.cs in `Stop()` where the `CancelationTokenSource` is cancelled but `_sendTask.Wait()` never returns which is causing the hang.

This solution is fairly simple and does the following:

1. Grabs the handle from `OnConnect()` when a new TCP link is established and stores the value in a new `_socketHandle` property
2. When `unlink` is issued, after the `CancelationTokenSource` is cancelled, CloseHandle() is called on that handle
3. Connection is closed, the function returns, and the link is removed

There might be a more eloquent solution by figuring out why the sendTask never returns but figured this is a good starting place for discussion. 