### PR TITLE
Resource saving while idle and during initial connection

### DIFF
--- a/Payload_Type/apollo/agent_code/Apollo/Agent/Apollo.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Agent/Apollo.cs
@@ -82,6 +82,7 @@ namespace Apollo.Agent
                         c2.Start();
                     }
                 }
+                System.Threading.Thread.Sleep(1000);
             }
         }
 

--- a/Payload_Type/apollo/agent_code/Apollo/Management/Tasks/TaskManager.cs
+++ b/Payload_Type/apollo/agent_code/Apollo/Management/Tasks/TaskManager.cs
@@ -94,6 +94,10 @@ namespace Apollo.Management.Tasks
                         }
 
                     }
+                    else
+                    {
+                        Thread.Sleep(100);
+                    }
                 }
             };
             _mainworker = new ThreadingTask(_taskConsumerAction);

--- a/Payload_Type/apollo/agent_code/HttpProfile/HttpProfile.cs
+++ b/Payload_Type/apollo/agent_code/HttpProfile/HttpProfile.cs
@@ -34,6 +34,7 @@ namespace HttpTransport
         private string ProxyAddress;
         private Dictionary<string, string> _additionalHeaders = new Dictionary<string, string>();
         private bool _uuidNegotiated = false;
+        private RSAKeyGenerator rsa = null;
 
         public HttpProfile(Dictionary<string, string> data, ISerializer serializer, IAgent agent) : base(data, serializer, agent)
         {
@@ -45,6 +46,7 @@ namespace HttpTransport
             EncryptedExchangeCheck = data["encrypted_exchange_check"] == "T";
             ProxyHost = data["proxy_host"];
             ProxyPort = data["proxy_port"];
+            rsa = agent.GetApi().NewRSAKeyPair(4096);
             if (!string.IsNullOrEmpty(ProxyPort))
             {
                 ProxyAddress = string.Format("{0}:{1}", ProxyHost, ProxyPort);
@@ -190,18 +192,16 @@ namespace HttpTransport
         {
             if (EncryptedExchangeCheck && !_uuidNegotiated)
             {
-                var rsa = Agent.GetApi().NewRSAKeyPair(4096);
-
                 EKEHandshakeMessage handshake1 = new EKEHandshakeMessage()
                 {
                     Action = "staging_rsa",
-                    PublicKey = rsa.ExportPublicKey(),
-                    SessionID = rsa.SessionId
+                    PublicKey = this.rsa.ExportPublicKey(),
+                    SessionID = this.rsa.SessionId
                 };
 
                 if (!SendRecv<EKEHandshakeMessage, EKEHandshakeResponse>(handshake1, delegate(EKEHandshakeResponse respHandshake)
                 {
-                    byte[] tmpKey = rsa.RSA.Decrypt(Convert.FromBase64String(respHandshake.SessionKey), true);
+                    byte[] tmpKey = this.rsa.RSA.Decrypt(Convert.FromBase64String(respHandshake.SessionKey), true);
                     ((ICryptographySerializer)Serializer).UpdateKey(Convert.ToBase64String(tmpKey));
                     ((ICryptographySerializer)Serializer).UpdateUUID(respHandshake.UUID);
                     return true;


### PR DESCRIPTION
As discussed on slack;

Change is tested on my local Mythic instance to the best of my ability.

**Problem A**

Currently an idle Apollo agent will always consume somewhere around 1 full CPU-core due to the task manager loop not backing off if there is nothing to process.

**Problem B.1**

The staging RSA key is generated for every connection attempt unless the EKE has completed. This causes quite high CPU usage during the initial phase if multiple attempts has to be done.

**Problem B.2**

If the initial checkin fails for some reason, it is immediately retried potentially flooding requests.

![image](https://user-images.githubusercontent.com/149442/177589608-2a2bd4db-11d8-411a-8c9f-317606291598.png)

**Fixes**

I propose:

 1) yielding back to the scheduler when there is nothing to do

 2) waiting a bit before retrying initial checkin

 3) caching the staging RSA key for EKE

Before the fixes, the worst case (an agent unable to connect to Mythic) looks like this in a profiler:

![image](https://user-images.githubusercontent.com/149442/177591919-3155a585-efe0-4bca-b965-bede8f26b834.png)


After fixes this is how VS 2019 shows the CPU graph. We can see the initial RSA generation, and then seemingly no other noticeable CPU consumers.
![image](https://user-images.githubusercontent.com/149442/177590214-1464c38f-92b5-4ea6-baa1-cc936076d835.png)
