### PR TITLE
Added explicit argument order to RunArguments. Fixes #113

### DIFF
--- a/Payload_Type/apollo/mythic/agent_functions/run.py
+++ b/Payload_Type/apollo/mythic/agent_functions/run.py
@@ -13,6 +13,12 @@ class RunArguments(TaskArguments):
                 display_name="Executable",
                 type=ParameterType.String,
                 description="Path to an executable to run.",
+                parameter_group_info=[
+                    ParameterGroupInfo(
+                        required=True,
+                        ui_position=0
+                    )
+                ]
             ),
             CommandParameter(
                 name="arguments",
@@ -23,6 +29,7 @@ class RunArguments(TaskArguments):
                 parameter_group_info=[
                     ParameterGroupInfo(
                         required=False,
+                        ui_position=1
                     )
                 ]),
         ]


### PR DESCRIPTION
Added ui_position attribute to command parameters in RunArguments to ensure the first argument is parsed as `executable` and the remainder are parsed as `arguments`