### PR TITLE
Fixing CP command argument positions

### DIFF
--- a/Payload_Type/apollo/mythic/agent_functions/cp.py
+++ b/Payload_Type/apollo/mythic/agent_functions/cp.py
@@ -12,13 +12,23 @@ class CpArguments(TaskArguments):
                 cli_name = "Path",
                 display_name = "Source file to copy.",
                 type=ParameterType.String,
-                description='Source file to copy.'),
+                description='Source file to copy.',
+                parameter_group_info=[
+                    ParaMeterGroupInfo(
+                        required=True,
+                        ui_position=0)
+                    ]),
             CommandParameter(
                 name="destination",
                 cli_name="Destination",
                 display_name="Destination path.",
                 type=ParameterType.String,
-                description="Where the new file will be created.")
+                description="Where the new file will be created.",
+                parameter_group_info=[
+                    ParaMeterGroupInfo(
+                        required=True,
+                        ui_position=1)
+                    ]))
         ]
 
     def split_commandline(self):

--- a/Payload_Type/apollo/mythic/agent_functions/cp.py
+++ b/Payload_Type/apollo/mythic/agent_functions/cp.py
@@ -28,7 +28,7 @@ class CpArguments(TaskArguments):
                     ParaMeterGroupInfo(
                         required=True,
                         ui_position=1)
-                    ]))
+                    ])
         ]
 
     def split_commandline(self):

--- a/Payload_Type/apollo/mythic/agent_functions/cp.py
+++ b/Payload_Type/apollo/mythic/agent_functions/cp.py
@@ -14,7 +14,7 @@ class CpArguments(TaskArguments):
                 type=ParameterType.String,
                 description='Source file to copy.',
                 parameter_group_info=[
-                    ParaMeterGroupInfo(
+                    ParameterGroupInfo(
                         required=True,
                         ui_position=0)
                     ]),
@@ -25,7 +25,7 @@ class CpArguments(TaskArguments):
                 type=ParameterType.String,
                 description="Where the new file will be created.",
                 parameter_group_info=[
-                    ParaMeterGroupInfo(
+                    ParameterGroupInfo(
                         required=True,
                         ui_position=1)
                     ])


### PR DESCRIPTION
This PR fixes the CP command's argument position. What the CP command currently does is `cp { destination } { source }`, but the documentation stated it should be `cp { source } { destination }`.