### PR TITLE
fixing reg_write_value

### DIFF
--- a/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Utils/RegistryUtils.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Utils/RegistryUtils.cs
@@ -14,19 +14,19 @@ namespace ApolloInterop.Utils
             switch (hive)
             {
                 case "HKU":
-                    regKey = Registry.Users.OpenSubKey(subkey);
+                    regKey = Registry.Users.OpenSubKey(subkey, true);
                     break;
                 case "HKCC":
-                    regKey = Registry.CurrentConfig.OpenSubKey(subkey);
+                    regKey = Registry.CurrentConfig.OpenSubKey(subkey, true);
                     break;
                 case "HKCU":
-                    regKey = Registry.CurrentUser.OpenSubKey(subkey);
+                    regKey = Registry.CurrentUser.OpenSubKey(subkey, true);
                     break;
                 case "HKLM":
-                    regKey = Registry.LocalMachine.OpenSubKey(subkey);
+                    regKey = Registry.LocalMachine.OpenSubKey(subkey, true);
                     break;
                 case "HKCR":
-                    regKey = Registry.ClassesRoot.OpenSubKey(subkey);
+                    regKey = Registry.ClassesRoot.OpenSubKey(subkey, true);
                     break;
                 default:
                     throw new Exception($"Unknown registry hive: {hive}");


### PR DESCRIPTION
reg_write_value command in apollo was unable to write to registry keys, kept getting unauthorized errors. Turns out to make the opened registry keys writable, a boolean value needs to be included as an argument. Since the reg_write_value uses the GetRegistryKey function to open the subkeys, we should ideally have write access to the opened subkeys, hence the change

Reference:
https://learn.microsoft.com/en-us/dotnet/api/microsoft.win32.registrykey.opensubkey?view=net-7.0#microsoft-win32-registrykey-opensubkey(system-string-system-boolean)