### PR TITLE
Add VS Code metadata files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.{py,js,cs}]
+indent_style = space
+indent_size = 4

--- a/Apollo.code-workspace
+++ b/Apollo.code-workspace
@@ -1,0 +1,16 @@
+{
+    "folders": [
+        {
+            "name": "Apollo code",
+            "path": "Payload_Type/apollo/apollo/agent_code"
+        },
+        {
+            "name": "Mythic code",
+            "path": "Payload_Type/apollo/apollo/mythic"
+        },
+        {
+            "name": "Project Root",
+            "path": "."
+        }
+    ],
+}

--- a/Apollo.code-workspace
+++ b/Apollo.code-workspace
@@ -13,4 +13,9 @@
             "path": "."
         }
     ],
+    "extensions": {
+        "recommendations": [
+            "EditorConfig.EditorConfig"
+        ]
+    }
 }

--- a/Payload_Type/apollo/apollo/agent_code/.editorconfig
+++ b/Payload_Type/apollo/apollo/agent_code/.editorconfig
@@ -1,0 +1,3 @@
+# Do not format the Apollo Config.cs file
+[Apollo/Config.cs]
+generated_code = true

--- a/Payload_Type/apollo/apollo/agent_code/.vscode/extensions.json
+++ b/Payload_Type/apollo/apollo/agent_code/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-dotnettools.csharp",
+        "ms-dotnettools.csdevkit"
+    ]
+}

--- a/Payload_Type/apollo/apollo/mythic/.vscode/extensions.json
+++ b/Payload_Type/apollo/apollo/mythic/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-python.python"
+    ]
+}


### PR DESCRIPTION
Add a VS Code workspace file to make Apollo easier to develop using VS Code.

UPDATES:
- Adds `.editorconfig` files for specifying common code formatting options.
- Adds workspace extension recommendations to VS Code.