### PR TITLE
Add prefixes to profile build parameters

### DIFF
--- a/Payload_Type/apollo/apollo/agent_code/Apollo/Config.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Apollo/Config.cs
@@ -53,17 +53,17 @@ namespace Apollo
                         { "killdate", "-1" },
                         { "USER_AGENT", "Apollo-Refactor" },
 #else
-                        { "callback_interval", "callback_interval_here" },
-                        { "callback_jitter", "callback_jitter_here" },
-                        { "callback_port", "callback_port_here" },
-                        { "callback_host", "callback_host_here" },
-                        { "post_uri", "post_uri_here" },
-                        { "encrypted_exchange_check", "encrypted_exchange_check_here" },
-                        { "proxy_host", "proxy_host_here" },
-                        { "proxy_port", "proxy_port_here" },
-                        { "proxy_user", "proxy_user_here" },
-                        { "proxy_pass", "proxy_pass_here" },
-                        { "killdate", "killdate_here" },
+                        { "callback_interval", "http_callback_interval_here" },
+                        { "callback_jitter", "http_callback_jitter_here" },
+                        { "callback_port", "http_callback_port_here" },
+                        { "callback_host", "http_callback_host_here" },
+                        { "post_uri", "http_post_uri_here" },
+                        { "encrypted_exchange_check", "http_encrypted_exchange_check_here" },
+                        { "proxy_host", "http_proxy_host_here" },
+                        { "proxy_port", "http_proxy_port_here" },
+                        { "proxy_user", "http_proxy_user_here" },
+                        { "proxy_pass", "http_proxy_pass_here" },
+                        { "killdate", "http_killdate_here" },
                         HTTP_ADDITIONAL_HEADERS_HERE
 #endif
                     }
@@ -90,16 +90,16 @@ namespace Apollo
                         { "killdate", "-1" },
                         { "USER_AGENT", "Apollo-Refactor" },
 #else
-                        { "tasking_type", "tasking_type_here"},
-                        { "callback_interval", "callback_interval_here" },
-                        { "callback_jitter", "callback_jitter_here" },
-                        { "callback_port", "callback_port_here" },
-                        { "callback_host", "callback_host_here" },
-                        { "ENDPOINT_REPLACE", "ENDPOINT_REPLACE_here" },
-                        { "encrypted_exchange_check", "encrypted_exchange_check_here" },
-                        { "domain_front", "domain_front_here" },
-                        { "USER_AGENT", "USER_AGENT_here" },
-                        { "killdate", "killdate_here" },
+                        { "tasking_type", "websocket_tasking_type_here"},
+                        { "callback_interval", "websocket_callback_interval_here" },
+                        { "callback_jitter", "websocket_callback_jitter_here" },
+                        { "callback_port", "websocket_callback_port_here" },
+                        { "callback_host", "websocket_callback_host_here" },
+                        { "ENDPOINT_REPLACE", "websocket_ENDPOINT_REPLACE_here" },
+                        { "encrypted_exchange_check", "websocket_encrypted_exchange_check_here" },
+                        { "domain_front", "websocket_domain_front_here" },
+                        { "USER_AGENT", "websocket_USER_AGENT_here" },
+                        { "killdate", "websocket_killdate_here" },
                         HTTP_ADDITIONAL_HEADERS_HERE
 #endif
                     }
@@ -118,8 +118,8 @@ namespace Apollo
                         { "pipename", "ahatojqq-bo0w-oc3r-wqtg-4jf7voepqqbs" },
                         { "encrypted_exchange_check", "T" },
 #else
-                        { "pipename", "pipename_here" },
-                        { "encrypted_exchange_check", "encrypted_exchange_check_here" },
+                        { "pipename", "smb_pipename_here" },
+                        { "encrypted_exchange_check", "smb_encrypted_exchange_check_here" },
 #endif
                     }
                 }
@@ -136,8 +136,8 @@ namespace Apollo
                         { "port", "40000" },
                         { "encrypted_exchange_check", "T" },
 #else
-                        { "port", "port_here" },
-                        { "encrypted_exchange_check", "encrypted_exchange_check_here" },
+                        { "port", "tcp_port_here" },
+                        { "encrypted_exchange_check", "tcp_encrypted_exchange_check_here" },
 #endif
                     }
                 }
@@ -167,6 +167,7 @@ namespace Apollo
         public static string PayloadUUID = "a51253f6-7885-4fea-9109-154ecc54060d";
 #endif
 #else
+        // TODO: Make the AES key a config option specific to each profile
         public static string StagingRSAPrivateKey = "AESPSK_here";
         public static string PayloadUUID = "payload_uuid_here";
 #endif

--- a/Payload_Type/apollo/apollo/mythic/agent_functions/builder.py
+++ b/Payload_Type/apollo/apollo/mythic/agent_functions/builder.py
@@ -53,23 +53,7 @@ A fully featured .NET 4.0 compatible training agent. Version: {}
         defines_commands_upper = [f"#define {x.upper()}" for x in self.commands.get_commands()]
         special_files_map = {
             "Config.cs": {
-                "callback_interval": "",
-                "callback_jitter": "",
-                "callback_port": "",
-                "callback_host": "",
-                "post_uri": "",
-                "proxy_host": "",
-                "proxy_port": "",
-                "proxy_user": "",
-                "proxy_pass": "",
-                # "domain_front": "",
-                "killdate": "",
-                # "USER_AGENT": "",
-                "pipename": "",
-                "port": "",
-                "encrypted_exchange_check": "",
                 "payload_uuid": self.uuid,
-                "AESPSK": "",
             },
         }
         extra_variables = {
@@ -82,17 +66,20 @@ A fully featured .NET 4.0 compatible training agent. Version: {}
             profile = c2.get_c2profile()
             defines_profiles_upper.append(f"#define {profile['name'].upper()}")
             for key, val in c2.get_parameters_dict().items():
+                prefixed_key = f"{profile['name'].lower()}_{key}"
                 if isinstance(val, dict) and 'enc_key' in val:
-                    stdout_err += "Setting {} to {}".format(key, val["enc_key"] if val["enc_key"] is not None else "")
+                    stdout_err += "Setting {} to {}".format(prefixed_key, val["enc_key"] if val["enc_key"] is not None else "")
+
+                    # TODO: Prefix the AESPSK variable and also make it specific to each profile
                     special_files_map["Config.cs"][key] = val["enc_key"] if val["enc_key"] is not None else ""
                 elif isinstance(val, str):
-                    special_files_map["Config.cs"][key] = val
+                    special_files_map["Config.cs"][prefixed_key] = val
                 elif isinstance(val, bool):
-                    special_files_map["Config.cs"][key] = "T" if val else "F"
+                    special_files_map["Config.cs"][prefixed_key] = "T" if val else "F"
                 elif isinstance(val, dict):
                     extra_variables = {**extra_variables, **val}
                 else:
-                    special_files_map["Config.cs"][key] = json.dumps(val)
+                    special_files_map["Config.cs"][prefixed_key] = json.dumps(val)
         try:
             # make a temp directory for it to live
             agent_build_path = tempfile.TemporaryDirectory(suffix=self.uuid)


### PR DESCRIPTION
Prefixes the profile build parameters with the profile name in order to resolve any profile parameter naming conflicts. The AESPSK build parameter needs to be prefixed when per-profile crypto support is added.