### PR TITLE
Resolve path casing in file uploads

### DIFF
--- a/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Utils/PathUtils.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Utils/PathUtils.cs
@@ -59,13 +59,12 @@ namespace ApolloInterop.Utils
 
             return result;
         }
-        
-        
+
         public static string StripPathOfHost(string path)
         {
             if (path.StartsWith(@"\\"))
             {
-                return new string(path.Skip(path.IndexOf('\\', 2)+1).ToArray());
+                return new string(path.Skip(path.IndexOf('\\', 2) + 1).ToArray());
             }
             return path;
         }

--- a/Payload_Type/apollo/apollo/agent_code/Tasks/upload.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Tasks/upload.cs
@@ -55,11 +55,13 @@ namespace Tasks
                         p.RemotePath,
                         p.FileName
                     });
-                } else
+                }
+                else
                 {
                     path = p.RemotePath;
                 }
-            } else
+            }
+            else
             {
                 path = Path.Combine(new string[]
                 {
@@ -71,7 +73,8 @@ namespace Tasks
             if (!string.IsNullOrEmpty(host))
             {
                 return string.Format(@"\\{0}\{1}", host, path);
-            } else
+            }
+            else
             {
                 FileInfo finfo = new FileInfo(path);
                 return finfo.FullName;

--- a/Payload_Type/apollo/apollo/agent_code/Tasks/upload.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Tasks/upload.cs
@@ -12,6 +12,8 @@ using ApolloInterop.Interfaces;
 using ApolloInterop.Structs.MythicStructs;
 using System.Runtime.Serialization;
 using System.IO;
+using ApolloInterop.Utils;
+using System.Linq;
 
 namespace Tasks
 {
@@ -20,7 +22,7 @@ namespace Tasks
         [DataContract]
         internal struct UploadParameters
         {
-            #pragma warning disable 0649
+#pragma warning disable 0649
             [DataMember(Name = "remote_path")]
             internal string RemotePath;
             [DataMember(Name = "file")]
@@ -29,7 +31,7 @@ namespace Tasks
             internal string FileName;
             [DataMember(Name = "host")]
             internal string HostName;
-            #pragma warning restore 0649
+#pragma warning restore 0649
         }
 
         public upload(IAgent agent, MythicTask mythicTask) : base(agent, mythicTask)
@@ -39,45 +41,67 @@ namespace Tasks
 
         internal string ParsePath(UploadParameters p)
         {
-            string host = "";
-            string path = "";
+            string uploadPath;
             if (!string.IsNullOrEmpty(p.HostName))
             {
-                host = p.HostName;
-            }
-            if (!string.IsNullOrEmpty(p.RemotePath))
-            {
-                if (Directory.Exists(p.RemotePath))
+                if (!string.IsNullOrEmpty(p.RemotePath))
                 {
-                    path = Path.Combine(new string[]
-                    {
-                        p.RemotePath,
-                        p.FileName
-                    });
+                    uploadPath = string.Format(@"\\{0}\{1}", p.HostName, p.RemotePath);
                 }
                 else
                 {
-                    path = p.RemotePath;
+                    // Remote paths require a share name
+                    throw new ArgumentException("SMB share name not specified.");
                 }
             }
             else
             {
-                path = Path.Combine(new string[]
+                if (!string.IsNullOrEmpty(p.RemotePath))
                 {
-                    Directory.GetCurrentDirectory(),
-                    p.FileName
-                });
+                    if (Path.IsPathRooted(p.RemotePath))
+                    {
+                        uploadPath = p.RemotePath;
+                    }
+                    else
+                    {
+                        uploadPath = Path.GetFullPath(p.RemotePath);
+                    }
+                }
+                else
+                {
+                    uploadPath = Directory.GetCurrentDirectory();
+                }
             }
 
-            if (!string.IsNullOrEmpty(host))
+            string unresolvedFilePath;
+            var uploadPathInfo = new DirectoryInfo(uploadPath);
+            if (uploadPathInfo.Exists)
             {
-                return string.Format(@"\\{0}\{1}", host, path);
+                unresolvedFilePath = Path.Combine([uploadPathInfo.FullName, p.FileName]);
+            }
+            else if (uploadPathInfo.Parent is DirectoryInfo parentInfo && parentInfo.Exists)
+            {
+                unresolvedFilePath = uploadPathInfo.FullName;
             }
             else
             {
-                FileInfo finfo = new FileInfo(path);
-                return finfo.FullName;
+                throw new ArgumentException($"{uploadPath} does not exist.");
             }
+
+            var parentPath = Path.GetDirectoryName(unresolvedFilePath);
+            var fileName = unresolvedFilePath.Split(Path.DirectorySeparatorChar).Last();
+
+            string resolvedParent;
+            if (PathUtils.TryGetExactPath(parentPath, out var resolved))
+            {
+                resolvedParent = resolved;
+            }
+            else
+            {
+                resolvedParent = parentPath;
+            }
+
+            return Path.Combine([resolvedParent, fileName]);
         }
 
 
@@ -92,9 +116,9 @@ namespace Tasks
                     parameters.FileID,
                     out byte[] fileData))
             {
-                string path = ParsePath(parameters);
                 try
                 {
+                    string path = ParsePath(parameters);
                     File.WriteAllBytes(path, fileData);
 
                     resp = CreateTaskResponse(

--- a/Payload_Type/apollo/apollo/agent_code/Tasks/upload.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Tasks/upload.cs
@@ -20,6 +20,7 @@ namespace Tasks
         [DataContract]
         internal struct UploadParameters
         {
+            #pragma warning disable 0649
             [DataMember(Name = "remote_path")]
             internal string RemotePath;
             [DataMember(Name = "file")]
@@ -28,6 +29,7 @@ namespace Tasks
             internal string FileName;
             [DataMember(Name = "host")]
             internal string HostName;
+            #pragma warning restore 0649
         }
 
         public upload(IAgent agent, MythicTask mythicTask) : base(agent, mythicTask)

--- a/Payload_Type/apollo/apollo/agent_code/Tasks/upload.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Tasks/upload.cs
@@ -43,10 +43,7 @@ namespace Tasks
             string path = "";
             if (!string.IsNullOrEmpty(p.HostName))
             {
-                if (p.HostName != "127.0.0.1" || p.HostName.ToLower() != "localhost")
-                {
-                    host = p.HostName;
-                }
+                host = p.HostName;
             }
             if (!string.IsNullOrEmpty(p.RemotePath))
             {

--- a/Payload_Type/apollo/apollo/mythic/agent_functions/upload.py
+++ b/Payload_Type/apollo/apollo/mythic/agent_functions/upload.py
@@ -20,12 +20,14 @@ class UploadArguments(TaskArguments):
                     ParameterGroupInfo(
                         required=False,
                     ),
-                ]),
+                ],
+            ),
             CommandParameter(
                 name="file",
                 cli_name="File",
                 display_name="File",
-                type=ParameterType.File),
+                type=ParameterType.File,
+            ),
             CommandParameter(
                 name="host",
                 cli_name="Host",
@@ -36,7 +38,8 @@ class UploadArguments(TaskArguments):
                     ParameterGroupInfo(
                         required=False,
                     ),
-                ]),
+                ],
+            ),
         ]
 
     async def parse_arguments(self):
@@ -66,30 +69,39 @@ class UploadCommand(CommandBase):
     author = "@djhohnstein"
     argument_class = UploadArguments
     attackmapping = ["T1132", "T1030", "T1105"]
-    attributes = CommandAttributes(
-        suggested_command=True
-    )
+    attributes = CommandAttributes(suggested_command=True)
 
-    async def create_go_tasking(self, taskData: PTTaskMessageAllData) -> PTTaskCreateTaskingMessageResponse:
+    async def create_go_tasking(
+        self, taskData: PTTaskMessageAllData
+    ) -> PTTaskCreateTaskingMessageResponse:
         response = PTTaskCreateTaskingMessageResponse(
             TaskID=taskData.Task.ID,
             Success=True,
         )
-        file_resp = await SendMythicRPCFileSearch(MythicRPCFileSearchMessage(
-            TaskID=taskData.Task.ID,
-            AgentFileID=taskData.args.get_arg("file")
-        ))
+        file_resp = await SendMythicRPCFileSearch(
+            MythicRPCFileSearchMessage(
+                TaskID=taskData.Task.ID, AgentFileID=taskData.args.get_arg("file")
+            )
+        )
         if file_resp.Success:
             original_file_name = file_resp.Files[0].Filename
         else:
-            raise Exception("Failed to fetch uploaded file from Mythic (ID: {})".format(taskData.args.get_arg("file")))
+            raise Exception(
+                "Failed to fetch uploaded file from Mythic (ID: {})".format(
+                    taskData.args.get_arg("file")
+                )
+            )
 
-        taskData.args.add_arg("file_name", original_file_name, type=ParameterType.String)
+        taskData.args.add_arg(
+            "file_name", original_file_name, type=ParameterType.String
+        )
         host = taskData.args.get_arg("host")
         path = taskData.args.get_arg("remote_path")
         if path is not None and path != "":
             if host is not None and host != "":
-                disp_str = "-File {} -Host {} -Path {}".format(original_file_name, host, path)
+                disp_str = "-File {} -Host {} -Path {}".format(
+                    original_file_name, host, path
+                )
             else:
                 disp_str = "-File {} -Path {}".format(original_file_name, path)
         else:
@@ -97,6 +109,8 @@ class UploadCommand(CommandBase):
         response.DisplayParams = disp_str
         return response
 
-    async def process_response(self, task: PTTaskMessageAllData, response: any) -> PTTaskProcessResponseMessageResponse:
+    async def process_response(
+        self, task: PTTaskMessageAllData, response: any
+    ) -> PTTaskProcessResponseMessageResponse:
         resp = PTTaskProcessResponseMessageResponse(TaskID=task.Task.ID, Success=True)
         return resp

--- a/Payload_Type/apollo/apollo/mythic/agent_functions/upload.py
+++ b/Payload_Type/apollo/apollo/mythic/agent_functions/upload.py
@@ -96,6 +96,15 @@ class UploadCommand(CommandBase):
             "file_name", original_file_name, type=ParameterType.String
         )
         host = taskData.args.get_arg("host")
+
+        # Remove any localhost aliases
+        if host and (
+            host.upper() == taskData.Callback.Host.upper()
+            or host == "127.0.0.1"
+            or host.lower() == "localhost"
+        ):
+            taskData.args.remove_arg("host")
+
         path = taskData.args.get_arg("remote_path")
         if path is not None and path != "":
             if host is not None and host != "":


### PR DESCRIPTION
Uploaded files would not have their full paths resolved to match the casing of the uploaded directory. This would result in the file getting uploaded successfully but the reported upload path would be incorrect since the casing of the path may not match the casing on the file system.

This PR has Apollo resolve the path locally first to find the correct path casing and them reports the fixed path back to Mythic to match the host's file system.