### PR TITLE
Support multiple IPs in initial checkin

### DIFF
--- a/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Structs/MythicStructs.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Structs/MythicStructs.cs
@@ -1000,8 +1000,8 @@ namespace ApolloInterop.Structs
             public int PID;
 
             [DataMember(Name = "process_name")] public string ProcessName;
-            [DataMember(Name = "ip")]
-            public string IP;
+            [DataMember(Name = "ips")]
+            public string[] IPs;
             [DataMember(Name = "uuid")]
             public string UUID;
             [DataMember(Name = "architecture")]


### PR DESCRIPTION
Adds support for returning multiple IP addresses in the initial checkin. IP addresses are returned with a preferential order with interfaces containing a gateway address and IPv4 addresses having a higher preference. This will help better display a default IP address in Mythic during the first checkin.

Fixes: #118
Closes: #119