### PR TITLE
More verbose execute PE error responses

### DIFF
--- a/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Classes/Core/Process.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Classes/Core/Process.cs
@@ -1,4 +1,4 @@
-﻿using ApolloInterop.Classes.Events;
+using ApolloInterop.Classes.Events;
 using ApolloInterop.Interfaces;
 using ApolloInterop.Structs.ApolloStructs;
 using System;
@@ -20,7 +20,7 @@ namespace ApolloInterop.Classes.Core
         public event EventHandler<StringDataEventArgs> OutputDataReceived;
         public event EventHandler<StringDataEventArgs> ErrorDataReceieved;
         public event EventHandler Exit;
-        
+
         public void OnOutputDataReceived(object sender, StringDataEventArgs args)
         {
             OutputDataReceived?.Invoke(sender, args);
@@ -37,7 +37,7 @@ namespace ApolloInterop.Classes.Core
         {
             Exit?.Invoke(sender, args);
         }
-        public Process(IAgent agent, string lpApplication, string lpArguments=null, bool startSuspended = false)
+        public Process(IAgent agent, string lpApplication, string lpArguments = null, bool startSuspended = false)
         {
             _agent = agent;
             if (string.IsNullOrEmpty(lpApplication) && string.IsNullOrEmpty(lpArguments))
@@ -48,10 +48,12 @@ namespace ApolloInterop.Classes.Core
             {
                 CommandLine = lpApplication;
                 Application = lpApplication;
-            } else if (string.IsNullOrEmpty(lpApplication))
+            }
+            else if (string.IsNullOrEmpty(lpApplication))
             {
                 CommandLine = lpArguments;
-            } else
+            }
+            else
             {
                 Application = lpApplication;
                 CommandLine = $"{lpApplication} {lpArguments}";

--- a/Payload_Type/apollo/apollo/agent_code/Tasks/execute_pe.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Tasks/execute_pe.cs
@@ -21,6 +21,7 @@ using ApolloInterop.Classes.Core;
 using ApolloInterop.Utils;
 using System.Threading.Tasks;
 using ApolloInterop.Classes.Events;
+using System.ComponentModel;
 
 namespace Tasks
 {
@@ -222,7 +223,17 @@ namespace Tasks
 
                 if (procHandle.ExitCode != 0)
                 {
-                    taskResponse.UserOutput = $"[*] Process exited with code: {procHandle.ExitCode}";
+                    if ((procHandle.ExitCode & 0xc0000000) != 0
+                        && procHandle.GetExitCodeHResult() is int exitCodeHResult)
+                    {
+                        var errorMessage = new Win32Exception(exitCodeHResult).Message;
+                        taskResponse.UserOutput = $"[*] Process exited with code: 0x{(uint)procHandle.ExitCode:x} - {errorMessage}";
+                        taskResponse.Status = "error";
+                    }
+                    else
+                    {
+                        taskResponse.UserOutput = $"[*] Process exited with code: {procHandle.ExitCode} - 0x{(uint)procHandle.ExitCode:x}";
+                    }
                 }
             }
 


### PR DESCRIPTION
Have execute PE return back the process exit code in decimal and unsigned hex if the return code was non-zero.

NT exit codes get returned back to Mythic with an error status along with the NT code message.