### PR TITLE
Updated make_token to support blank passwords

### DIFF
--- a/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Structs/ApolloStructs.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Structs/ApolloStructs.cs
@@ -54,8 +54,8 @@ namespace ApolloInterop.Structs.ApolloStructs
         {
             if (string.IsNullOrEmpty(username))
                 throw new Exception("Username cannot be null or empty.");
-            if (string.IsNullOrEmpty(password))
-                throw new Exception("Password cannot be null or empty.");
+            if (password == null)
+                throw new Exception("Password cannot be null.");
             SecurePassword = new SecureString();
             foreach (char c in password)
                 SecurePassword.AppendChar(c);

--- a/Payload_Type/apollo/apollo/agent_code/Tasks/make_token.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Tasks/make_token.cs
@@ -36,7 +36,7 @@ namespace Tasks
             {
                 resp = CreateTaskResponse("Account name is empty.", true, "error");
             }
-            else if (string.IsNullOrEmpty(parameters.Credential.CredentialMaterial))
+            else if (parameters.Credential.CredentialMaterial == null)
             {
                 resp = CreateTaskResponse("Password is empty.", true, "error");
             }


### PR DESCRIPTION
Modified the `make_token` command to accept empty strings as a password, to support scenarios where the target user has a blank password. 

| Before | After |
|---|---|
| <img width="1917" height="917" alt="image" src="https://github.com/user-attachments/assets/7262a9e2-8eef-45b9-8b71-ec8b21861527" /> | <img width="1918" height="915" alt="image" src="https://github.com/user-attachments/assets/0df93da5-5fd1-4ec7-aba2-093e2da5341a" /> |

Cheers