### PR TITLE
Fix/ldap browser

### DIFF
--- a/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Classes/Core/Tasking.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Classes/Core/Tasking.cs
@@ -73,6 +73,9 @@ namespace ApolloInterop.Classes
                         case MessageType.FileBrowser:
                             resp.FileBrowser = (FileBrowser)msg;
                             break;
+                        case MessageType.CustomBrowser:
+                            resp.Browser = (CustomBrowser)msg;
+                            break;
                         case MessageType.Credential:
                             creds.Add((Credential)msg);
                             break;

--- a/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Serializers/JsonSerializer.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Serializers/JsonSerializer.cs
@@ -29,7 +29,10 @@ namespace ApolloInterop.Serializers
         {
             using (var ms = new MemoryStream())
             {
-                var ser = new DataContractJsonSerializer(msg.GetType());
+                var ser = new DataContractJsonSerializer(msg.GetType(), new DataContractJsonSerializerSettings
+                {
+                    UseSimpleDictionaryFormat = true
+                });
                 ser.WriteObject(ms, msg);
                 ms.Position = 0;
                 using (var sr = new StreamReader(ms))
@@ -44,7 +47,10 @@ namespace ApolloInterop.Serializers
         {
             using (var ms = new MemoryStream(Encoding.Unicode.GetBytes(msg)))
             {
-                var deserializer = new DataContractJsonSerializer(typeof(T));
+                var deserializer = new DataContractJsonSerializer(typeof(T), new DataContractJsonSerializerSettings
+                {
+                    UseSimpleDictionaryFormat = true
+                });
                 return (T)deserializer.ReadObject(ms);
             }
         }
@@ -53,7 +59,10 @@ namespace ApolloInterop.Serializers
         {
             using (var ms = new MemoryStream(Encoding.Unicode.GetBytes(msg)))
             {
-                var deserializer = new DataContractJsonSerializer(t);
+                var deserializer = new DataContractJsonSerializer(t, new DataContractJsonSerializerSettings
+                {
+                    UseSimpleDictionaryFormat = true
+                });
                 return deserializer.ReadObject(ms);
             }
         }

--- a/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Structs/MythicStructs.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Structs/MythicStructs.cs
@@ -1304,6 +1304,8 @@ namespace ApolloInterop.Structs
             public string Name;
             [DataMember(Name = "can_have_children")]
             public bool CanHaveChildren;
+            [DataMember(Name = "display_path", EmitDefaultValue = false)]
+            public string? DisplayPath;
             [DataMember(Name = "metadata", EmitDefaultValue = false)]
             public Dictionary<string, object>? Metadata;
         }

--- a/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Structs/MythicStructs.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Structs/MythicStructs.cs
@@ -1315,7 +1315,7 @@ namespace ApolloInterop.Structs
             [DataMember(Name = "parent_path")]
             public string ParentPath;
             [DataMember(Name = "display_path")]
-            public string DispalyPath;
+            public string DisplayPath;
             [DataMember(Name = "success", EmitDefaultValue = false)]
             public bool? Success;
             [DataMember(Name = "can_have_children")]

--- a/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Types/MythicTypes.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Types/MythicTypes.cs
@@ -29,6 +29,10 @@ namespace ApolloInterop.Types
             {
                 return typeof(FileBrowser);
             }
+            else if (msg == MessageType.CustomBrowser)
+            {
+                return typeof(CustomBrowser);
+            }
             else if (msg == MessageType.EdgeNode)
             {
                 return typeof(EdgeNode);

--- a/Payload_Type/apollo/apollo/agent_code/Tasks/ldap_query.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Tasks/ldap_query.cs
@@ -457,20 +457,11 @@ namespace Tasks
                     string dnString = NormalizeLdapDn(dn.ToString());
                     customBrowserEntry.DisplayPath = dnString;
                     string[] dnStringPieces = dnString.Split(',');
-                    customBrowserEntry.Name = dnStringPieces[0];
-                    dnStringPieces = dnStringPieces.Skip(1).Take(dnStringPieces.Length-1).Reverse().ToArray();
-                    customBrowserEntry.ParentPath = string.Join(",", dnStringPieces);
-                    customBrowserEntry.Metadata = user.ToDictionary(
-                        item => item.Key,
-                        item => item.Value is IEnumerable<string> values
-                            ? (object)string.Join(" | ", values.Select(NormalizeMetadataString))
-                            : item.Value is string value
-                                ? (object)NormalizeMetadataString(value)
-                                : item.Value);
-                    int nameEqualsIndex = customBrowserEntry.Name.IndexOf('=');
+                    string firstRdn = dnStringPieces[0];
+                    int nameEqualsIndex = firstRdn.IndexOf('=');
                     string displayName = nameEqualsIndex >= 0
-                        ? customBrowserEntry.Name.Substring(nameEqualsIndex + 1).Trim()
-                        : customBrowserEntry.Name;
+                        ? firstRdn.Substring(nameEqualsIndex + 1).Trim()
+                        : firstRdn;
                     foreach (string displayKey in new[] { "cn", "name", "samaccountname" })
                     {
                         KeyValuePair<string, object> displayItem = user.FirstOrDefault(item =>
@@ -481,6 +472,16 @@ namespace Tasks
                             break;
                         }
                     }
+                    customBrowserEntry.Name = displayName;
+                    dnStringPieces = dnStringPieces.Skip(1).Take(dnStringPieces.Length-1).Reverse().ToArray();
+                    customBrowserEntry.ParentPath = string.Join(",", dnStringPieces);
+                    customBrowserEntry.Metadata = user.ToDictionary(
+                        item => item.Key,
+                        item => item.Value is IEnumerable<string> values
+                            ? (object)string.Join(" | ", values.Select(NormalizeMetadataString))
+                            : item.Value is string value
+                                ? (object)NormalizeMetadataString(value)
+                                : item.Value);
                     bool isGroup = false;
                     bool isContainer = false;
                     if(user.TryGetValue("objectclass", out object oc) && oc != null)
@@ -495,8 +496,6 @@ namespace Tasks
 
                     }
                     customBrowserEntry.Metadata["ldap_type"] = isGroup ? "group" : isContainer ? "container" : "object";
-                    customBrowserEntry.Metadata["display_name"] = displayName;
-                    customBrowserEntry.Metadata["dn"] = dnString;
                     List<string> members = new List<string>();
                     if (user.TryGetValue("member", out object memberValue) && memberValue != null)
                     {
@@ -513,24 +512,20 @@ namespace Tasks
                     {
                         customBrowserEntry.Children = members.Select(memberDn =>
                         {
-                            string memberName = memberDn.Split(',')[0];
-                            int memberEqualsIndex = memberName.IndexOf('=');
+                            string memberFirstRdn = memberDn.Split(',')[0];
+                            int memberEqualsIndex = memberFirstRdn.IndexOf('=');
                             string memberDisplayName = memberEqualsIndex >= 0
-                                ? memberName.Substring(memberEqualsIndex + 1).Trim()
-                                : memberName;
+                                ? memberFirstRdn.Substring(memberEqualsIndex + 1).Trim()
+                                : memberFirstRdn;
                             return new CustomBrowserEntryChild
                             {
-                                Name = memberDn,
+                                Name = memberDisplayName,
                                 DisplayPath = memberDn,
                                 CanHaveChildren = false,
                                 Metadata = new Dictionary<string, object>
                                 {
                                     { "ldap_type", "member_link" },
-                                    { "display_name", memberDisplayName },
-                                    { "dn", memberDn },
-                                    { "target_dn", memberDn },
-                                    { "distinguishedname", memberDn },
-                                    { "name", memberName }
+                                    { "target_dn", memberDn }
                                 }
                             };
                         }).ToList();

--- a/Payload_Type/apollo/apollo/agent_code/Tasks/ldap_query.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Tasks/ldap_query.cs
@@ -300,7 +300,7 @@ namespace Tasks
         {
         }
 
-        string[] groupClasses = { "group", "domain", "domainDNS", "organizationalUnit", "container", "builtinDomain" };
+        string[] containerClasses = { "domain", "domainDNS", "organizationalUnit", "container", "builtinDomain" };
 
         private static string NormalizeLdapDn(string dn)
         {
@@ -410,16 +410,16 @@ namespace Tasks
                         searchScope: SearchScope.Base
                     );
                     bool baseIsGroup = false;
-                    bool baseCanHaveChildren = false;
+                    bool baseIsContainer = false;
                     if (baseResults.Count > 0 && baseResults[0].TryGetValue("objectclass", out object baseObjectClass) && baseObjectClass != null)
                     {
                         IEnumerable<string> baseClasses = baseObjectClass is IEnumerable<string> baseValues
                             ? baseValues
                             : new[] { baseObjectClass.ToString() };
                         baseIsGroup = baseClasses.Any(x => string.Equals(x, "group", StringComparison.OrdinalIgnoreCase));
-                        baseCanHaveChildren = baseClasses.Intersect(groupClasses, StringComparer.OrdinalIgnoreCase).Any();
+                        baseIsContainer = baseClasses.Intersect(containerClasses, StringComparer.OrdinalIgnoreCase).Any();
                     }
-                    if (baseIsGroup || !baseCanHaveChildren)
+                    if (baseIsGroup || !baseIsContainer)
                     {
                         results = baseResults;
                     }
@@ -468,6 +468,7 @@ namespace Tasks
                                 ? (object)NormalizeMetadataString(value)
                                 : item.Value);
                     bool isGroup = false;
+                    bool isContainer = false;
                     if(user.TryGetValue("objectclass", out object oc) && oc != null)
                     {
                         IEnumerable<string> classes = oc is IEnumerable<string> values
@@ -475,12 +476,11 @@ namespace Tasks
                             : new[] { oc.ToString() };
 
                         isGroup = classes.Any(x => string.Equals(x, "group", StringComparison.OrdinalIgnoreCase));
-                        if (classes.Intersect(groupClasses, StringComparer.OrdinalIgnoreCase).Any())
-                        {
-                            customBrowserEntry.CanHaveChildren = true;
-                        }
+                        isContainer = classes.Intersect(containerClasses, StringComparer.OrdinalIgnoreCase).Any();
+                        customBrowserEntry.CanHaveChildren = isGroup || isContainer;
 
                     }
+                    customBrowserEntry.Metadata["ldap_type"] = isGroup ? "group" : isContainer ? "container" : "object";
                     List<string> members = new List<string>();
                     if (user.TryGetValue("member", out object memberValue) && memberValue != null)
                     {
@@ -499,9 +499,11 @@ namespace Tasks
                         {
                             Name = memberDn,
                             DisplayPath = memberDn,
-                            CanHaveChildren = true,
+                            CanHaveChildren = false,
                             Metadata = new Dictionary<string, object>
                             {
+                                { "ldap_type", "member_link" },
+                                { "target_dn", memberDn },
                                 { "distinguishedname", memberDn },
                                 { "name", memberDn.Split(',')[0] }
                             }

--- a/Payload_Type/apollo/apollo/agent_code/Tasks/ldap_query.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Tasks/ldap_query.cs
@@ -497,7 +497,7 @@ namespace Tasks
                     {
                         customBrowserEntry.Children = members.Select(memberDn => new CustomBrowserEntryChild
                         {
-                            Name = memberDn.Split(',')[0],
+                            Name = memberDn,
                             DisplayPath = memberDn,
                             CanHaveChildren = true,
                             Metadata = new Dictionary<string, object>

--- a/Payload_Type/apollo/apollo/agent_code/Tasks/ldap_query.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Tasks/ldap_query.cs
@@ -302,6 +302,52 @@ namespace Tasks
 
         string[] groupClasses = { "group", "domain", "domainDNS", "organizationalUnit", "container", "builtinDomain" };
 
+        private static string NormalizeLdapDn(string dn)
+        {
+            if (string.IsNullOrEmpty(dn))
+            {
+                return dn;
+            }
+            if (dn.StartsWith("LDAP://", StringComparison.OrdinalIgnoreCase))
+            {
+                dn = dn.Substring(7);
+            }
+            return string.Join(",", dn.Split(',')
+                .Select(piece => piece.Trim())
+                .Where(piece => piece != "")
+                .Select(piece =>
+                {
+                    int equalsIndex = piece.IndexOf('=');
+                    if (equalsIndex <= 0)
+                    {
+                        return piece;
+                    }
+                    string attribute = piece.Substring(0, equalsIndex).Trim();
+                    string value = piece.Substring(equalsIndex + 1).Trim();
+                    return string.Equals(attribute, "DC", StringComparison.OrdinalIgnoreCase)
+                        ? $"DC={value.ToUpperInvariant()}"
+                        : piece;
+                }));
+        }
+
+        private static string NormalizeMetadataString(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+            string candidate = value.StartsWith("LDAP://", StringComparison.OrdinalIgnoreCase)
+                ? value.Substring(7)
+                : value;
+            string[] pieces = candidate.Split(',')
+                .Select(piece => piece.Trim())
+                .Where(piece => piece != "")
+                .ToArray();
+            return pieces.Length > 1 && pieces.All(piece => piece.Contains("="))
+                ? NormalizeLdapDn(value)
+                : value;
+        }
+
         public override void Start()
         {
             MythicTaskResponse resp;
@@ -314,23 +360,24 @@ namespace Tasks
             customBrowser.SetAsUserOutput = true;
             //customBrowser.UpdateDeleted = true;
             customBrowser.Entries = new List<CustomBrowserEntry>();
-            string ldapBase = parameters.Base;
+            string ldapBase = NormalizeLdapDn(parameters.Base);
             ActiveDirectoryLdapQuery query;
-            if (ldapBase != "")
+            if (!string.IsNullOrEmpty(ldapBase))
             {
-                query = new ActiveDirectoryLdapQuery($"LDAP://{parameters.Base}");
-                string[] domainPieces = parameters.Base.Split(',')
+                query = new ActiveDirectoryLdapQuery($"LDAP://{ldapBase}");
+                string[] domainPieces = ldapBase.Split(',')
                     .Where(x => x.Trim().StartsWith("DC=", StringComparison.OrdinalIgnoreCase))
                     .ToArray();
-                customBrowser.Host = domainPieces.Length > 0 ? string.Join(",", domainPieces) : parameters.Base;
+                customBrowser.Host = domainPieces.Length > 0 ? string.Join(",", domainPieces) : ldapBase;
             } else
             {
                 Domain domain = Domain.GetCurrentDomain();
                 DirectoryEntry ent = domain.GetDirectoryEntry();
                 string path = ent.Path;
                 string[] pathPieces = ent.Path.Split('/');
-                query = new ActiveDirectoryLdapQuery($"LDAP://{pathPieces[pathPieces.Length - 1]}");
-                customBrowser.Host = pathPieces[pathPieces.Length - 1];
+                string domainDn = NormalizeLdapDn(pathPieces[pathPieces.Length - 1]);
+                query = new ActiveDirectoryLdapQuery($"LDAP://{domainDn}");
+                customBrowser.Host = domainDn;
             }
 
             List<Dictionary<string, object>> results = new List<Dictionary<string, object>>();
@@ -407,8 +454,7 @@ namespace Tasks
                 CustomBrowserEntry customBrowserEntry = new CustomBrowserEntry();
                 if(user.TryGetValue("DistinguishedName", out object dn))
                 {
-                    string dnString = dn.ToString();
-                    dnString = dnString.Replace("LDAP://", "");
+                    string dnString = NormalizeLdapDn(dn.ToString());
                     customBrowserEntry.DisplayPath = dnString;
                     string[] dnStringPieces = dnString.Split(',');
                     customBrowserEntry.Name = dnStringPieces[0];
@@ -417,8 +463,10 @@ namespace Tasks
                     customBrowserEntry.Metadata = user.ToDictionary(
                         item => item.Key,
                         item => item.Value is IEnumerable<string> values
-                            ? (object)string.Join(" | ", values)
-                            : item.Value);
+                            ? (object)string.Join(" | ", values.Select(NormalizeMetadataString))
+                            : item.Value is string value
+                                ? (object)NormalizeMetadataString(value)
+                                : item.Value);
                     bool isGroup = false;
                     if(user.TryGetValue("objectclass", out object oc) && oc != null)
                     {
@@ -438,11 +486,11 @@ namespace Tasks
                     {
                         if (memberValue is IEnumerable<string> memberValues)
                         {
-                            members = memberValues.ToList();
+                            members = memberValues.Select(NormalizeLdapDn).ToList();
                         }
                         else
                         {
-                            members.Add(memberValue.ToString());
+                            members.Add(NormalizeLdapDn(memberValue.ToString()));
                         }
                     }
                     if (isGroup && members.Count > 0)

--- a/Payload_Type/apollo/apollo/agent_code/Tasks/ldap_query.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Tasks/ldap_query.cs
@@ -354,12 +354,16 @@ namespace Tasks
                 {
                     string dnString = dn.ToString();
                     dnString = dnString.Replace("LDAP://", "");
-                    customBrowserEntry.DispalyPath = dnString;
+                    customBrowserEntry.DisplayPath = dnString;
                     string[] dnStringPieces = dnString.Split(',');
                     customBrowserEntry.Name = dnStringPieces[0];
                     dnStringPieces = dnStringPieces.Skip(1).Take(dnStringPieces.Length-1).Reverse().ToArray();
                     customBrowserEntry.ParentPath = string.Join(",", dnStringPieces);
-                    customBrowserEntry.Metadata = user;
+                    customBrowserEntry.Metadata = user.ToDictionary(
+                        item => item.Key,
+                        item => item.Value is IEnumerable<string> values
+                            ? (object)string.Join(" | ", values)
+                            : item.Value);
                     if(user.TryGetValue("objectclass", out object oc))
                     {
                         List<string> classes = (List<string>)oc;

--- a/Payload_Type/apollo/apollo/agent_code/Tasks/ldap_query.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Tasks/ldap_query.cs
@@ -467,6 +467,20 @@ namespace Tasks
                             : item.Value is string value
                                 ? (object)NormalizeMetadataString(value)
                                 : item.Value);
+                    int nameEqualsIndex = customBrowserEntry.Name.IndexOf('=');
+                    string displayName = nameEqualsIndex >= 0
+                        ? customBrowserEntry.Name.Substring(nameEqualsIndex + 1).Trim()
+                        : customBrowserEntry.Name;
+                    foreach (string displayKey in new[] { "cn", "name", "samaccountname" })
+                    {
+                        KeyValuePair<string, object> displayItem = user.FirstOrDefault(item =>
+                            string.Equals(item.Key, displayKey, StringComparison.OrdinalIgnoreCase));
+                        if (!string.IsNullOrEmpty(displayItem.Key) && displayItem.Value != null && !string.IsNullOrEmpty(displayItem.Value.ToString()))
+                        {
+                            displayName = displayItem.Value.ToString();
+                            break;
+                        }
+                    }
                     bool isGroup = false;
                     bool isContainer = false;
                     if(user.TryGetValue("objectclass", out object oc) && oc != null)
@@ -481,6 +495,8 @@ namespace Tasks
 
                     }
                     customBrowserEntry.Metadata["ldap_type"] = isGroup ? "group" : isContainer ? "container" : "object";
+                    customBrowserEntry.Metadata["display_name"] = displayName;
+                    customBrowserEntry.Metadata["dn"] = dnString;
                     List<string> members = new List<string>();
                     if (user.TryGetValue("member", out object memberValue) && memberValue != null)
                     {
@@ -495,18 +511,28 @@ namespace Tasks
                     }
                     if (isGroup && members.Count > 0)
                     {
-                        customBrowserEntry.Children = members.Select(memberDn => new CustomBrowserEntryChild
+                        customBrowserEntry.Children = members.Select(memberDn =>
                         {
-                            Name = memberDn,
-                            DisplayPath = memberDn,
-                            CanHaveChildren = false,
-                            Metadata = new Dictionary<string, object>
+                            string memberName = memberDn.Split(',')[0];
+                            int memberEqualsIndex = memberName.IndexOf('=');
+                            string memberDisplayName = memberEqualsIndex >= 0
+                                ? memberName.Substring(memberEqualsIndex + 1).Trim()
+                                : memberName;
+                            return new CustomBrowserEntryChild
                             {
-                                { "ldap_type", "member_link" },
-                                { "target_dn", memberDn },
-                                { "distinguishedname", memberDn },
-                                { "name", memberDn.Split(',')[0] }
-                            }
+                                Name = memberDn,
+                                DisplayPath = memberDn,
+                                CanHaveChildren = false,
+                                Metadata = new Dictionary<string, object>
+                                {
+                                    { "ldap_type", "member_link" },
+                                    { "display_name", memberDisplayName },
+                                    { "dn", memberDn },
+                                    { "target_dn", memberDn },
+                                    { "distinguishedname", memberDn },
+                                    { "name", memberName }
+                                }
+                            };
                         }).ToList();
                     }
                     customBrowser.Entries.Add(customBrowserEntry);

--- a/Payload_Type/apollo/apollo/agent_code/Tasks/ldap_query.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Tasks/ldap_query.cs
@@ -300,7 +300,7 @@ namespace Tasks
         {
         }
 
-        string[] groupClasses = { "group", "domain", "organizationalUnit", "container" };
+        string[] groupClasses = { "group", "domain", "domainDNS", "organizationalUnit", "container", "builtinDomain" };
 
         public override void Start()
         {
@@ -350,12 +350,6 @@ namespace Tasks
             }
             try
             {
-                results = query.Query(
-                    filter: filter,
-                    attributesToReturn: parameters.attributes,
-                    limit: parameters.limit,
-                    searchScope: searchScope
-                );
                 if (searchScope == SearchScope.OneLevel && !string.IsNullOrEmpty(ldapBase))
                 {
                     string[] baseAttributes = (parameters.attributes ?? new string[0])
@@ -369,17 +363,37 @@ namespace Tasks
                         searchScope: SearchScope.Base
                     );
                     bool baseIsGroup = false;
+                    bool baseCanHaveChildren = false;
                     if (baseResults.Count > 0 && baseResults[0].TryGetValue("objectclass", out object baseObjectClass) && baseObjectClass != null)
                     {
                         IEnumerable<string> baseClasses = baseObjectClass is IEnumerable<string> baseValues
                             ? baseValues
                             : new[] { baseObjectClass.ToString() };
                         baseIsGroup = baseClasses.Any(x => string.Equals(x, "group", StringComparison.OrdinalIgnoreCase));
+                        baseCanHaveChildren = baseClasses.Intersect(groupClasses, StringComparer.OrdinalIgnoreCase).Any();
                     }
-                    if (baseIsGroup)
+                    if (baseIsGroup || !baseCanHaveChildren)
                     {
-                        results.Insert(0, baseResults[0]);
+                        results = baseResults;
                     }
+                    else
+                    {
+                        results = query.Query(
+                            filter: filter,
+                            attributesToReturn: parameters.attributes,
+                            limit: parameters.limit,
+                            searchScope: searchScope
+                        );
+                    }
+                }
+                else
+                {
+                    results = query.Query(
+                        filter: filter,
+                        attributesToReturn: parameters.attributes,
+                        limit: parameters.limit,
+                        searchScope: searchScope
+                    );
                 }
             }catch (Exception ex)
             {

--- a/Payload_Type/apollo/apollo/agent_code/Tasks/ldap_query.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Tasks/ldap_query.cs
@@ -293,13 +293,15 @@ namespace Tasks
             public string[] attributes;
             [DataMember(Name = "limit")]
             public int limit;
+            [DataMember(Name = "scope")]
+            public string scope;
         }
-
         public ldap_query(IAgent agent, ApolloInterop.Structs.MythicStructs.MythicTask data) : base(agent, data)
         {
         }
 
         string[] groupClasses = { "group", "domain", "organizationalUnit", "container" };
+
         public override void Start()
         {
             MythicTaskResponse resp;
@@ -317,6 +319,10 @@ namespace Tasks
             if (ldapBase != "")
             {
                 query = new ActiveDirectoryLdapQuery($"LDAP://{parameters.Base}");
+                string[] domainPieces = parameters.Base.Split(',')
+                    .Where(x => x.Trim().StartsWith("DC=", StringComparison.OrdinalIgnoreCase))
+                    .ToArray();
+                customBrowser.Host = domainPieces.Length > 0 ? string.Join(",", domainPieces) : parameters.Base;
             } else
             {
                 Domain domain = Domain.GetCurrentDomain();
@@ -333,13 +339,48 @@ namespace Tasks
             {
                 filter = "(&(objectclass=top)(objectclass=container))";
             }
+            SearchScope searchScope = SearchScope.Subtree;
+            if (string.Equals(parameters.scope, "onelevel", StringComparison.OrdinalIgnoreCase))
+            {
+                searchScope = SearchScope.OneLevel;
+            }
+            else if (string.Equals(parameters.scope, "base", StringComparison.OrdinalIgnoreCase))
+            {
+                searchScope = SearchScope.Base;
+            }
             try
             {
                 results = query.Query(
                     filter: filter,
                     attributesToReturn: parameters.attributes,
-                    limit: parameters.limit
+                    limit: parameters.limit,
+                    searchScope: searchScope
                 );
+                if (searchScope == SearchScope.OneLevel && !string.IsNullOrEmpty(ldapBase))
+                {
+                    string[] baseAttributes = (parameters.attributes ?? new string[0])
+                        .Concat(new[] { "cn", "samaccountname", "description", "member", "memberOf", "objectclass", "distinguishedname" })
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToArray();
+                    List<Dictionary<string, object>> baseResults = query.Query(
+                        filter: "(objectClass=*)",
+                        attributesToReturn: baseAttributes,
+                        limit: 1,
+                        searchScope: SearchScope.Base
+                    );
+                    bool baseIsGroup = false;
+                    if (baseResults.Count > 0 && baseResults[0].TryGetValue("objectclass", out object baseObjectClass) && baseObjectClass != null)
+                    {
+                        IEnumerable<string> baseClasses = baseObjectClass is IEnumerable<string> baseValues
+                            ? baseValues
+                            : new[] { baseObjectClass.ToString() };
+                        baseIsGroup = baseClasses.Any(x => string.Equals(x, "group", StringComparison.OrdinalIgnoreCase));
+                    }
+                    if (baseIsGroup)
+                    {
+                        results.Insert(0, baseResults[0]);
+                    }
+                }
             }catch (Exception ex)
             {
                 _agent.GetTaskManager().AddTaskResponseToQueue(CreateTaskResponse(
@@ -364,15 +405,45 @@ namespace Tasks
                         item => item.Value is IEnumerable<string> values
                             ? (object)string.Join(" | ", values)
                             : item.Value);
-                    if(user.TryGetValue("objectclass", out object oc))
+                    bool isGroup = false;
+                    if(user.TryGetValue("objectclass", out object oc) && oc != null)
                     {
-                        List<string> classes = (List<string>)oc;
+                        IEnumerable<string> classes = oc is IEnumerable<string> values
+                            ? values
+                            : new[] { oc.ToString() };
 
-                        if (classes.Intersect(groupClasses).Count() > 0)
+                        isGroup = classes.Any(x => string.Equals(x, "group", StringComparison.OrdinalIgnoreCase));
+                        if (classes.Intersect(groupClasses, StringComparer.OrdinalIgnoreCase).Any())
                         {
                             customBrowserEntry.CanHaveChildren = true;
                         }
 
+                    }
+                    List<string> members = new List<string>();
+                    if (user.TryGetValue("member", out object memberValue) && memberValue != null)
+                    {
+                        if (memberValue is IEnumerable<string> memberValues)
+                        {
+                            members = memberValues.ToList();
+                        }
+                        else
+                        {
+                            members.Add(memberValue.ToString());
+                        }
+                    }
+                    if (isGroup && members.Count > 0)
+                    {
+                        customBrowserEntry.Children = members.Select(memberDn => new CustomBrowserEntryChild
+                        {
+                            Name = memberDn.Split(',')[0],
+                            DisplayPath = memberDn,
+                            CanHaveChildren = true,
+                            Metadata = new Dictionary<string, object>
+                            {
+                                { "distinguishedname", memberDn },
+                                { "name", memberDn.Split(',')[0] }
+                            }
+                        }).ToList();
                     }
                     customBrowser.Entries.Add(customBrowserEntry);
                 }

--- a/Payload_Type/apollo/apollo/mythic/agent_functions/ldap_query.py
+++ b/Payload_Type/apollo/apollo/mythic/agent_functions/ldap_query.py
@@ -94,7 +94,7 @@ class LdapQueryArguments(TaskArguments):
                 if isinstance(path_value, str) and path_value and data["full_path"].startswith(path_value + ","):
                     path_remainder = data["full_path"][len(path_value) + 1:]
                 path_remainder_pieces = [x.strip() for x in path_remainder.split(",") if x.strip()]
-                dn = data.get("display_path") or metadata.get("distinguishedname") or metadata.get("DistinguishedName")
+                dn = data.get("display_path") or metadata.get("target_dn") or metadata.get("distinguishedname") or metadata.get("DistinguishedName")
                 if not dn and len(file_dn_pieces) > 1 and all("=" in x for x in file_dn_pieces):
                     dn = file_dn
                 if not dn and len(path_remainder_pieces) > 1 and all("=" in x for x in path_remainder_pieces):

--- a/Payload_Type/apollo/apollo/mythic/agent_functions/ldap_query.py
+++ b/Payload_Type/apollo/apollo/mythic/agent_functions/ldap_query.py
@@ -84,7 +84,22 @@ class LdapQueryArguments(TaskArguments):
                 metadata = data.get("metadata", {})
                 if isinstance(metadata, list):
                     metadata = {x["Key"]: x["Value"] for x in metadata if "Key" in x and "Value" in x}
-                dn = data.get("display_path") or metadata.get("distinguishedname") or metadata.get("DistinguishedName") or data["full_path"]
+                file_dn = data.get("file", "")
+                file_dn = file_dn.strip().strip('"') if isinstance(file_dn, str) else ""
+                if file_dn.lower().startswith("ldap://"):
+                    file_dn = file_dn[7:]
+                file_dn_pieces = [x.strip() for x in file_dn.split(",") if x.strip()]
+                path_remainder = ""
+                path_value = data.get("path", "")
+                if isinstance(path_value, str) and path_value and data["full_path"].startswith(path_value + ","):
+                    path_remainder = data["full_path"][len(path_value) + 1:]
+                path_remainder_pieces = [x.strip() for x in path_remainder.split(",") if x.strip()]
+                dn = data.get("display_path") or metadata.get("distinguishedname") or metadata.get("DistinguishedName")
+                if not dn and len(file_dn_pieces) > 1 and all("=" in x for x in file_dn_pieces):
+                    dn = file_dn
+                if not dn and len(path_remainder_pieces) > 1 and all("=" in x for x in path_remainder_pieces):
+                    dn = path_remainder
+                dn = dn or data["full_path"]
                 if dn.lower().startswith("ldap://"):
                     dn = dn[7:]
                 if dn == data["full_path"]:

--- a/Payload_Type/apollo/apollo/mythic/agent_functions/ldap_query.py
+++ b/Payload_Type/apollo/apollo/mythic/agent_functions/ldap_query.py
@@ -60,6 +60,20 @@ class LdapQueryArguments(TaskArguments):
                     )
                 ],
                 default_value=100,),
+            CommandParameter(
+                name="scope",
+                cli_name="scope",
+                display_name="Search Scope",
+                type=ParameterType.ChooseOne,
+                choices=["subtree", "onelevel", "base"],
+                description="LDAP search scope",
+                parameter_group_info=[
+                    ParameterGroupInfo(
+                        required=False,
+                        ui_position=5,
+                    )
+                ],
+                default_value="subtree",),
         ]
 
 
@@ -67,11 +81,28 @@ class LdapQueryArguments(TaskArguments):
         if self.command_line[0] == "{":
             data = json.loads(self.command_line)
             if "full_path" in data:
-                self.add_arg("query", data["query"] if "query" in data else "")
-                self.add_arg("base", data["host"] if "host" in data else "")
-                search_attributes = [x.strip() for x in data["attributes"].split(",") if x != ""] if "attributes" in data else []
-                if len(search_attributes) > 0:
-                    self.add_arg("attributes", search_attributes)
+                metadata = data.get("metadata", {})
+                if isinstance(metadata, list):
+                    metadata = {x["Key"]: x["Value"] for x in metadata if "Key" in x and "Value" in x}
+                dn = metadata.get("distinguishedname", metadata.get("DistinguishedName", data.get("display_path", data["full_path"])))
+                if dn.startswith("LDAP://"):
+                    dn = dn[7:]
+                if dn == data["full_path"]:
+                    dn_pieces = [x.strip() for x in dn.split(",") if x.strip()]
+                    if len(dn_pieces) > 0 and dn_pieces[0].lower().startswith("dc="):
+                        dn = ",".join(reversed(dn_pieces))
+                self.add_arg("base", dn)
+                self.add_arg("query", data["query"] if "query" in data and data["query"] else "(objectClass=*)")
+                raw_attributes = data["attributes"] if "attributes" in data else ""
+                if isinstance(raw_attributes, list):
+                    search_attributes = raw_attributes
+                else:
+                    search_attributes = [x.strip() for x in raw_attributes.split(",") if x.strip()]
+                if len(search_attributes) == 0:
+                    search_attributes = ["cn", "samaccountname", "description", "member", "memberOf", "objectclass", "distinguishedname"]
+                self.add_arg("attributes", search_attributes)
+                self.add_arg("limit", data["limit"] if "limit" in data else 100)
+                self.add_arg("scope", data["scope"] if "scope" in data else "onelevel")
                 return
             self.load_args_from_json_string(self.command_line)
         else:

--- a/Payload_Type/apollo/apollo/mythic/agent_functions/ldap_query.py
+++ b/Payload_Type/apollo/apollo/mythic/agent_functions/ldap_query.py
@@ -94,7 +94,13 @@ class LdapQueryArguments(TaskArguments):
                 if isinstance(path_value, str) and path_value and data["full_path"].startswith(path_value + ","):
                     path_remainder = data["full_path"][len(path_value) + 1:]
                 path_remainder_pieces = [x.strip() for x in path_remainder.split(",") if x.strip()]
-                dn = data.get("display_path") or metadata.get("target_dn") or metadata.get("distinguishedname") or metadata.get("DistinguishedName")
+                def _is_valid_dn(value):
+                    if not value:
+                        return False
+                    pieces = [x.strip() for x in value.split(",") if x.strip()]
+                    return len(pieces) > 0 and all("=" in p for p in pieces)
+                display_path = data.get("display_path", "")
+                dn = (display_path if _is_valid_dn(display_path) else None) or metadata.get("target_dn") or metadata.get("distinguishedname") or metadata.get("DistinguishedName")
                 if not dn and len(file_dn_pieces) > 1 and all("=" in x for x in file_dn_pieces):
                     dn = file_dn
                 if not dn and len(path_remainder_pieces) > 1 and all("=" in x for x in path_remainder_pieces):

--- a/Payload_Type/apollo/apollo/mythic/agent_functions/ldap_query.py
+++ b/Payload_Type/apollo/apollo/mythic/agent_functions/ldap_query.py
@@ -85,7 +85,7 @@ class LdapQueryArguments(TaskArguments):
                 if isinstance(metadata, list):
                     metadata = {x["Key"]: x["Value"] for x in metadata if "Key" in x and "Value" in x}
                 dn = data.get("display_path") or metadata.get("distinguishedname") or metadata.get("DistinguishedName") or data["full_path"]
-                if dn.startswith("LDAP://"):
+                if dn.lower().startswith("ldap://"):
                     dn = dn[7:]
                 if dn == data["full_path"]:
                     dn_pieces = [x.strip() for x in dn.split(",") if x.strip()]
@@ -106,8 +106,15 @@ class LdapQueryArguments(TaskArguments):
                 query = data["query"].strip().strip('"') if "query" in data and data["query"] else "(objectClass=*)"
                 query_pieces = [x.strip() for x in query.split(",") if x.strip()]
                 if not query.startswith("(") and len(query_pieces) > 0 and all("=" in x for x in query_pieces):
-                    dn = query[7:] if query.startswith("LDAP://") else query
+                    dn = query[7:] if query.lower().startswith("ldap://") else query
                     query = "(objectClass=*)"
+                dn = ",".join([
+                    "DC={}".format(piece.split("=", 1)[1].strip().upper())
+                    if "=" in piece and piece.split("=", 1)[0].strip().lower() == "dc"
+                    else piece.strip()
+                    for piece in dn.split(",")
+                    if piece.strip()
+                ])
                 self.add_arg("base", dn)
                 self.add_arg("query", query)
                 raw_attributes = data["attributes"] if "attributes" in data else ""

--- a/Payload_Type/apollo/apollo/mythic/agent_functions/ldap_query.py
+++ b/Payload_Type/apollo/apollo/mythic/agent_functions/ldap_query.py
@@ -84,12 +84,24 @@ class LdapQueryArguments(TaskArguments):
                 metadata = data.get("metadata", {})
                 if isinstance(metadata, list):
                     metadata = {x["Key"]: x["Value"] for x in metadata if "Key" in x and "Value" in x}
-                dn = metadata.get("distinguishedname", metadata.get("DistinguishedName", data.get("display_path", data["full_path"])))
+                dn = data.get("display_path") or metadata.get("distinguishedname") or metadata.get("DistinguishedName") or data["full_path"]
                 if dn.startswith("LDAP://"):
                     dn = dn[7:]
                 if dn == data["full_path"]:
                     dn_pieces = [x.strip() for x in dn.split(",") if x.strip()]
-                    if len(dn_pieces) > 0 and dn_pieces[0].lower().startswith("dc="):
+                    host_pieces = [x.strip() for x in data.get("host", "").split(",") if x.strip()]
+                    lower_dn_pieces = [x.lower() for x in dn_pieces]
+                    lower_host_pieces = [x.lower() for x in host_pieces]
+                    lower_reversed_host_pieces = list(reversed(lower_host_pieces))
+                    if len(host_pieces) > 0 and lower_dn_pieces[-len(host_pieces):] == lower_host_pieces:
+                        dn = ",".join(dn_pieces)
+                    elif len(host_pieces) > 0 and lower_dn_pieces[:len(host_pieces)] == lower_host_pieces:
+                        dn = ",".join(list(reversed(dn_pieces[len(host_pieces):])) + host_pieces)
+                    elif len(host_pieces) > 0 and lower_dn_pieces[:len(host_pieces)] == lower_reversed_host_pieces:
+                        dn = ",".join(list(reversed(dn_pieces[len(host_pieces):])) + host_pieces)
+                    elif len(host_pieces) > 0:
+                        dn = ",".join(list(reversed(dn_pieces)) + host_pieces)
+                    elif len(dn_pieces) > 0 and dn_pieces[0].lower().startswith("dc="):
                         dn = ",".join(reversed(dn_pieces))
                 self.add_arg("base", dn)
                 self.add_arg("query", data["query"] if "query" in data and data["query"] else "(objectClass=*)")

--- a/Payload_Type/apollo/apollo/mythic/agent_functions/ldap_query.py
+++ b/Payload_Type/apollo/apollo/mythic/agent_functions/ldap_query.py
@@ -103,8 +103,13 @@ class LdapQueryArguments(TaskArguments):
                         dn = ",".join(list(reversed(dn_pieces)) + host_pieces)
                     elif len(dn_pieces) > 0 and dn_pieces[0].lower().startswith("dc="):
                         dn = ",".join(reversed(dn_pieces))
+                query = data["query"].strip().strip('"') if "query" in data and data["query"] else "(objectClass=*)"
+                query_pieces = [x.strip() for x in query.split(",") if x.strip()]
+                if not query.startswith("(") and len(query_pieces) > 0 and all("=" in x for x in query_pieces):
+                    dn = query[7:] if query.startswith("LDAP://") else query
+                    query = "(objectClass=*)"
                 self.add_arg("base", dn)
-                self.add_arg("query", data["query"] if "query" in data and data["query"] else "(objectClass=*)")
+                self.add_arg("query", query)
                 raw_attributes = data["attributes"] if "attributes" in data else ""
                 if isinstance(raw_attributes, list):
                     search_attributes = raw_attributes


### PR DESCRIPTION
* Fix CustomBrowser LDAP responses

Adds CustomBrowser response handling, normalizes LDAP DN casing, classifies LDAP rows, emits usable browser metadata, and serializes metadata as JSON objects so custom columns populate.

* Improve LDAP browser tasking and metadata

Fixes LDAP browser crashes and bad follow-up tasking by flattening LDAP metadata safely, preserving real DNs for member links, and exposing stable row fields like ldap_type, display_name, and dn.