### PR TITLE
Constant-time HMAC comparison

### DIFF
--- a/Payload_Type/apollo/apollo/agent_code/PSKCrypto/PSKCryptographyProvider.cs
+++ b/Payload_Type/apollo/apollo/agent_code/PSKCrypto/PSKCryptographyProvider.cs
@@ -14,6 +14,8 @@ namespace PSKCryptography
             
         }
 
+        // This should be a safe way to compare secret values without leaking timing info
+        // https://github.com/veorq/cryptocoding#compare-secret-strings-in-constant-time
         static public bool ConstTimeCompare(string rhs, string lhs)
         {
             if (rhs.Length != lhs.Length)
@@ -22,7 +24,7 @@ namespace PSKCryptography
             }
             var missed = 0;
             for (var idx = 0; idx < rhs.Length; idx++) {
-                missed ^= lhs[idx] ^ rhs[idx];
+                missed |= lhs[idx] ^ rhs[idx];
             }
             return missed == 0;
         }

--- a/Payload_Type/apollo/apollo/agent_code/PSKCrypto/PSKCryptographyProvider.cs
+++ b/Payload_Type/apollo/apollo/agent_code/PSKCrypto/PSKCryptographyProvider.cs
@@ -14,6 +14,19 @@ namespace PSKCryptography
             
         }
 
+        static public bool ConstTimeCompare(string rhs, string lhs)
+        {
+            if (rhs.Length != lhs.Length)
+            {
+                return false;
+            }
+            var missed = 0;
+            for (var idx = 0; idx < rhs.Length; idx++) {
+                missed ^= lhs[idx] ^ rhs[idx];
+            }
+            return missed == 0;
+        }
+
 
         public override string Encrypt(string plaintext)
         {
@@ -63,7 +76,7 @@ namespace PSKCryptography
             byte[] hmac = new byte[32];
             Array.Copy(input, uuidLength + 16 + ciphertext.Length, hmac, 0, 32);
 
-            if (Convert.ToBase64String(hmac) == Convert.ToBase64String(sha256.ComputeHash(IV.Concat(ciphertext).ToArray())))
+            if (ConstTimeCompare(Convert.ToBase64String(hmac), Convert.ToBase64String(sha256.ComputeHash(IV.Concat(ciphertext).ToArray()))))
             {
                 using (Aes scAes = Aes.Create())
                 {


### PR DESCRIPTION
Use a constant-time function to compare HMAC values.

The current code uses the language's basic `==` operator to compare the expected value to the one obtained from the network message. This may enable HMAC forging through a timing attack.

Although I believe my fix is sound, I have not been able to test whether it truly is constant time.